### PR TITLE
Install date bulk insert

### DIFF
--- a/WorkOrderInstallDateBl.cs
+++ b/WorkOrderInstallDateBl.cs
@@ -1,4 +1,4 @@
-﻿using WFMS.WorkOrderExecution.Model;
+using WFMS.WorkOrderExecution.Model;
 using WFMS.WorkOrderExecution.Model.Dto;
 using WFMS.WorkOrderExecution.BL.Utility;
 using System.Threading.Tasks;
@@ -13,7 +13,6 @@ using System.Diagnostics;
 using Xamarin.Forms.Internals;
 using System.Threading;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Concurrent;
 using OlameterFramework.EventBus.IntegrationEventLog;
 
 namespace WFMS.WorkOrderExecution.BL.BusinessLayer
@@ -31,6 +30,10 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
         private readonly IMessageIntegrationEventLogService _eventLogService;
         private readonly IKafkaHelper _kafkaHelper;
 
+        // History write batching: avoid one DbContext + SaveChanges per work order
+        private const int HistoryBatchSize = 200;
+        private const int HistoryMaxParallelBatches = 4;
+
         public WorkOrderInstallDateBl(ApplicationDbContext context,IWorkOrderBlackOutBl blackOutBl,IMapper mapper,
             IMessageIntegrationEventLogService eventLogService, IKafkaHelper kafkaHelper)
         {
@@ -46,9 +49,10 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             Stopwatch st = new Stopwatch();
             st.Start();
             List<InstallDateException> exceptions = new List<InstallDateException>();
-            ConcurrentBag<Task> historiesTask = new ConcurrentBag<Task>();
-            List<WorkOrderInstallDateDto> insideBlackOutList = new List<WorkOrderInstallDateDto>();
-            List<WorkOrderInstallDateDto> missingCycleRouteList = new List<WorkOrderInstallDateDto>();
+            List<(WorkOrderModel Current, WorkOrderModel Previous)> historiesToWrite = new List<(WorkOrderModel, WorkOrderModel)>();
+
+            HashSet<string> insideBlackOutNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HashSet<string> missingCycleRouteNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             int count = 0;
 
@@ -70,44 +74,65 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             else
                 workOrders = workOrders.Where(x => data.WorkOrders.Select(y => y.Name).Contains(x.Name)).AsQueryable();
 
+            // Materialize once; the previous implementation re-materialized workOrders multiple times.
+            List<WorkOrderModel> workOrderList = await workOrders.ToListAsync();
+            Dictionary<string, WorkOrderInstallDateDto> dtoByName = (data.WorkOrders ?? new List<WorkOrderInstallDateDto>())
+                .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
 
             if (data.Date > DateTime.MinValue)
             {
-                workOrders.Select(x => new { x.ContractName, x.ServiceType }).Distinct().ToList().ForEach(x =>
+                // If these fields are missing, we can mark all as missing without iterating the blackout rules.
+                if (cycleField == null || routeField == null)
                 {
-                    List<NextBlackOutDto> blackouts = _blackOutBl.GetAllBlackOuts(x.ContractName, x.ServiceType, data.Date);
-                    workOrders.Where(y => y.ContractName == x.ContractName && y.ServiceType == x.ServiceType).ToList()
-                              .ForEach(y => {
-                                  WorkOrderInstallDateDto dto = data.WorkOrders.Single(z => z.Name == y.Name);
+                    foreach (var wo in workOrderList)
+                        missingCycleRouteNames.Add(wo.Name);
+                }
 
-                                  if (cycleField == null || routeField == null)
-                                      missingCycleRouteList.Add(dto);
-                                  
-                                  else if (ValidateBlackOut(y, blackouts,data.Date,cycleField,routeField))
-                                      insideBlackOutList.Add(dto);
-                              });
-                });
+                foreach (var group in workOrderList.GroupBy(x => new { x.ContractName, x.ServiceType }))
+                {
+                    // Blackouts are requested once per (contract, serviceType)
+                    List<NextBlackOutDto> blackouts = _blackOutBl.GetAllBlackOuts(group.Key.ContractName, group.Key.ServiceType, data.Date);
+                    if (blackouts == null || blackouts.Count == 0)
+                        continue;
+
+                    // Only check blackout conditions if we have the necessary fields.
+                    if (cycleField == null || routeField == null)
+                        continue;
+
+                    foreach (var wo in group)
+                    {
+                        if (ValidateBlackOut(wo, blackouts, data.Date, cycleField, routeField))
+                            insideBlackOutNames.Add(wo.Name);
+                    }
+                }
             }
 
-            WorkOrderModel[] computedWorkOrders = new WorkOrderModel[0];
-
-            workOrders.AsParallel().ForEach(wo =>
+            // NOTE: DbContext is not thread-safe, do NOT use AsParallel() here.
+            List<WorkOrderModel> computedWorkOrders = new List<WorkOrderModel>(workOrderList.Count);
+            foreach (var wo in workOrderList)
             {
                 bool hasException = false;
                 try
                 {
                     WorkOrderModel previous = _mapper.Map(wo, new WorkOrderModel());
 
-                    if (missingCycleRouteList.Any(x => x.Name == wo.Name))
-                        throw new InstallDateException(wo.Name, $"Work Order {wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")} should have the field cycle/route");
+                    if (missingCycleRouteNames.Contains(wo.Name))
+                    {
+                        string woId = workOrderIdField == null ? wo.Name : wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")?.ToString();
+                        throw new InstallDateException(wo.Name, $"Work Order {woId} should have the field cycle/route");
+                    }
 
                     //Important: Temp solution blackout should be in the message because the UI need it to filter the blocking exception
-                    if (insideBlackOutList.Any(x => x.Name == wo.Name))
-                        exceptions.Add(new InstallDateException(wo.Name, $"Work Order {wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")} is inside a blackout"));
+                    if (insideBlackOutNames.Contains(wo.Name))
+                    {
+                        string woId = workOrderIdField == null ? wo.Name : wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")?.ToString();
+                        exceptions.Add(new InstallDateException(wo.Name, $"Work Order {woId} is inside a blackout"));
+                    }
 
                     wo.InstallDate = data.Date;
 
-                    AddHistory(wo, previous, username, ref historiesTask);
+                    AddHistory(wo, previous, username, ref historiesToWrite);
 
                 }
                 catch (InstallDateException e)
@@ -122,25 +147,23 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 }
                 finally
                 {
-                    if (!hasException) {
-                        Array.Resize(ref computedWorkOrders,computedWorkOrders.Length+1);
-                        computedWorkOrders[computedWorkOrders.Length - 1] = wo;
-                    }
+                    if (!hasException)
+                        computedWorkOrders.Add(wo);
                         
 
                     Interlocked.Increment(ref count);
                 }
-            });
+            }
 
             await _context.SaveChangesAsync();
 
-            Parallel.ForEachAsync(historiesTask,async (task,token) => task.Start());
+            await WriteHistoriesBatchedAsync(historiesToWrite, username);
             
             st.Stop();
             LoggerUtil.LogDebug($"Async Parallel Duration: {st.Elapsed.TotalSeconds}");
             return new InstallDateResultDto
             {
-                Computed = computedWorkOrders,
+                Computed = computedWorkOrders.ToArray(),
                 Error = exceptions.Select(e => new InstallDateErrorDto { 
                     Name = e.WorkOrderName,
                     Message = e.Message 
@@ -165,22 +188,53 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             return result;
         }
 
-        protected virtual void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username,ref ConcurrentBag<Task> historiesTask)
+        protected virtual void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username, ref List<(WorkOrderModel Current, WorkOrderModel Previous)> historiesToWrite)
         {
-            Task historyTask = new Task(() =>
+            historiesToWrite.Add((current, previous));
+        }
+
+        private async Task WriteHistoriesBatchedAsync(List<(WorkOrderModel Current, WorkOrderModel Previous)> histories, string username)
+        {
+            if (histories == null || histories.Count == 0)
+                return;
+
+            // Limit parallelism to avoid exhausting DB connections.
+            using SemaphoreSlim gate = new SemaphoreSlim(HistoryMaxParallelBatches, HistoryMaxParallelBatches);
+            List<Task> batchTasks = new List<Task>();
+
+            for (int i = 0; i < histories.Count; i += HistoryBatchSize)
             {
-                using (ApplicationDbContext taskContext = new ApplicationDbContext())
+                int start = i;
+                int count = Math.Min(HistoryBatchSize, histories.Count - start);
+                batchTasks.Add(Task.Run(async () =>
                 {
-                    HistoryBl historyBl = new HistoryBl(taskContext
-                                            , new WoGenericEnumValuesBl(taskContext)
-                                            , new AuditLogBl(taskContext)
-                                            , new HistoryDal(taskContext),_mapper, _kafkaHelper);
+                    await gate.WaitAsync();
+                    try
+                    {
+                        using ApplicationDbContext taskContext = new ApplicationDbContext();
+                        HistoryBl historyBl = new HistoryBl(taskContext,
+                            new WoGenericEnumValuesBl(taskContext),
+                            new AuditLogBl(taskContext),
+                            new HistoryDal(taskContext),
+                            _mapper,
+                            _kafkaHelper);
 
-                    historyBl.Create(current, previous, username, true);
-                }
-            });
+                        // Save once per batch (best-effort) instead of once per work order.
+                        for (int j = 0; j < count; j++)
+                        {
+                            var item = histories[start + j];
+                            bool andSave = (j == count - 1);
+                            historyBl.Create(item.Current, item.Previous, username, andSave);
+                        }
+                    }
+                    finally
+                    {
+                        gate.Release();
+                    }
+                }));
+            }
 
-            historiesTask.Add(historyTask);
+            await Task.WhenAll(batchTasks);
         }
     }
 }

--- a/WorkOrderInstallDateBl.cs
+++ b/WorkOrderInstallDateBl.cs
@@ -75,7 +75,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 workOrders = workOrders.Where(x => data.WorkOrders.Select(y => y.Name).Contains(x.Name)).AsQueryable();
 
             // Materialize once; the previous implementation re-materialized workOrders multiple times.
-            List<WorkOrderModel> workOrderList = await workOrders.ToListAsync();
+            List<WorkOrderModel> workOrderList = await ToListCompatAsync(workOrders);
             Dictionary<string, WorkOrderInstallDateDto> dtoByName = (data.WorkOrders ?? new List<WorkOrderInstallDateDto>())
                 .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
@@ -235,6 +235,18 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             }
 
             await Task.WhenAll(batchTasks);
+        }
+
+        /// <summary>
+        /// Supports unit tests that use mocked/in-memory IQueryable providers that don't implement EF async.
+        /// In production (EF Core provider), this uses ToListAsync.
+        /// </summary>
+        private static Task<List<T>> ToListCompatAsync<T>(IQueryable<T> query, CancellationToken cancellationToken = default)
+        {
+            if (query is IAsyncEnumerable<T>)
+                return EntityFrameworkQueryableExtensions.ToListAsync(query, cancellationToken);
+
+            return Task.FromResult(query.ToList());
         }
     }
 }

--- a/WorkOrderInstallDateBlTests.cs
+++ b/WorkOrderInstallDateBlTests.cs
@@ -1,0 +1,216 @@
+using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using OlameterFramework.DatabaseUtilities;
+using OlameterFramework.OFramework.ConfigUtils;
+using OlameterFramework.OFramework.Utils;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using OlameterFramework.EventBus.IntegrationEventLog;
+using WFMS.WorkOrderExecution.BL.BusinessLayer;
+using WFMS.WorkOrderExecution.DAL;
+using WFMS.WorkOrderExecution.Model;
+using WFMS.WorkOrderExecution.Model.Dto;
+using WFMS.WorkOrderExecution.Model.MappingConfigurations;
+using WFMS.WorkOrderExecution.BL.Utility;
+
+namespace WFMS.WorkOrderExecution.Tests
+{
+    [TestClass]
+    public class WorkOrderInstallDateBlTests
+    {
+        private readonly IInstallDateBl _bl;
+        private readonly ApplicationDbContext _context;
+        private readonly IWorkOrderBlackOutBl _blackoutBL;
+        private readonly IMapper _mapper;
+        private readonly IMessageIntegrationEventLogService _eventLogService;
+        private IKafkaHelper _kafkaHelper;
+
+        public WorkOrderInstallDateBlTests()
+        {
+            var mappingConfig = new MapperConfiguration(mc =>
+            {
+                mc.AddProfile(new WorkOrderModelProfile());
+            });
+
+            _mapper = mappingConfig.CreateMapper();
+            _blackoutBL = Substitute.For<IWorkOrderBlackOutBl>();
+            _context = Substitute.For<ApplicationDbContext>();
+            _kafkaHelper = Substitute.For<IKafkaHelper>();
+            DbSet<WorkOrderModel> workOrders = InitializeMockDBSet(new List<WorkOrderModel> {
+                new WorkOrderModel{
+                    Name = "1",
+                    ServiceType = "Power",
+                    ContractName = "A",
+                    JsonData = JsonDocument.Parse(new {Asset = new { InstallDate = string.Empty}, WorkOrder = new { WorkOrderId = "1",Cycle = "1",Route = "a"} }.ToJsonString())
+                },
+                new WorkOrderModel{
+                    Name = "2",
+                    ServiceType = "Power",
+                    ContractName = "A",
+                    JsonData = JsonDocument.Parse(new {Asset = new { InstallDate = string.Empty}, WorkOrder = new { WorkOrderId = "1",Cycle = "2",Route = "a"} }.ToJsonString())
+                },
+                new WorkOrderModel{
+                    Name = "3",
+                    ServiceType = "Power",
+                    ContractName = "A",
+                    JsonData = JsonDocument.Parse(new {Asset = new { InstallDate = string.Empty}, WorkOrder = new { WorkOrderId = "1"} }.ToJsonString())
+                },
+                new WorkOrderModel{
+                    Name = "4",
+                    ServiceType = "Power",
+                    ContractName = "A",
+                    JsonData = JsonDocument.Parse(new { WorkOrder = new { WorkOrderId = "1",Cycle = "2",Route = "a"} }.ToJsonString())
+                }
+            }.AsQueryable());
+            _context.Set<WorkOrderModel>().Returns(workOrders);
+            _context.Set<WorkOrderModel>().AsQueryable().Returns(workOrders);
+
+            DbSet<ContractImportedFieldModel> contractImportedFields = InitializeMockDBSet(new List<ContractImportedFieldModel> {
+                new ContractImportedFieldModel { Name = WorkOrderFieldName.InstallDateFN, Category="Asset",ContractName= "A" },
+                new ContractImportedFieldModel { Name = WorkOrderFieldName.WorkOrderIdFN, Category="WorkOrder",ContractName= "A" },
+                new ContractImportedFieldModel { Name = WorkOrderFieldName.CycleFN, Category="WorkOrder",ContractName= "A" },
+                new ContractImportedFieldModel { Name = WorkOrderFieldName.RouteFN, Category="WorkOrder",ContractName= "A" }
+                }.AsQueryable());
+
+            _context.Set<ContractImportedFieldModel>().Returns(contractImportedFields);
+            _context.Set<ContractImportedFieldModel>().AsQueryable().Returns(contractImportedFields);
+
+            _blackoutBL.GetAllBlackOuts(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>()).Returns(new List<NextBlackOutDto> {
+                new NextBlackOutDto{
+                    ContractId = "A",
+                    Cycle = "2",
+                    Route = "a",
+                    ServiceType = "Power",
+                    EndDate = DateTime.Now.AddDays(2).Date,
+                    StartDate = DateTime.Now.Date,
+                }
+            });
+
+            _bl = new WorkOrderInstallDateBlTest(_context, _blackoutBL, _mapper,_eventLogService, _kafkaHelper);
+        }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+        }
+
+        private DbSet<T> InitializeMockDBSet<T>(IQueryable<T> data) where T : BaseModel
+        {
+            DbSet<T> mockSet = Substitute.For<DbSet<T>, IQueryable<T>>();
+            ((IQueryable<T>)mockSet).Provider.Returns(data.Provider);
+            ((IQueryable<T>)mockSet).Expression.Returns(data.Expression);
+            ((IQueryable<T>)mockSet).ElementType.Returns(data.ElementType);
+            ((IQueryable<T>)mockSet).GetEnumerator().Returns(data.GetEnumerator());
+
+            return mockSet;
+        }
+
+        [TestMethod]
+        public async Task SetDateNoBlackOut_Succeed() {
+            const int n = 100_000;
+            List<WorkOrderInstallDateDto> workOrders = Enumerable.Range(1, n)
+                .Select(i => new WorkOrderInstallDateDto {
+                    Name = i.ToString(),
+                    ContractName= "A",
+                    ServiceType = "Power"
+                })
+                .ToList();
+
+            // Keep the original work order ("1") present, since the mocked DbSet contains only a few records.
+            // This still stresses the "large input list" path in the BL.
+            workOrders[0] = new WorkOrderInstallDateDto { Name = "1", ContractName = "A", ServiceType = "Power" };
+
+            InstallDateResultDto result = await _bl.SetInstallDate(new InstallDateDto
+            {
+                WorkOrders = workOrders,
+                Date = DateTime.Now.Date,
+                IsAll = false,
+            }, "test");
+
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Computed.Count() > 0);
+            Assert.IsTrue(!result.Error.Any());
+        }
+
+        [TestMethod]
+        public async Task SetDateWithBlackOut_Succeed()
+        {
+            InstallDateResultDto result = await _bl.SetInstallDate(new InstallDateDto
+            {
+                WorkOrders = new List<WorkOrderInstallDateDto> {
+                                new WorkOrderInstallDateDto {
+                                    Name = "2",
+                                    ContractName= "A",
+                                    ServiceType = "Power"
+                                } },
+                Date = DateTime.Now.Date,
+                IsAll = false,
+            }, "test");
+
+            Assert.IsNotNull(result);
+           // Assert.IsTrue(result.Computed.Count() > 0);
+            Assert.IsTrue(result.Error.Any());
+        }
+
+        // For now Cycle and Route path are hardcoded, should be change for the path with ContractImportedField
+        [Ignore]
+        [TestMethod]
+        public async Task SetDateWithoutCycleAndRouteInJson_Succeed()
+        {
+            InstallDateResultDto result = await _bl.SetInstallDate(new InstallDateDto
+            {
+                WorkOrders = new List<WorkOrderInstallDateDto> {
+                                new WorkOrderInstallDateDto {
+                                    Name = "3",
+                                    ContractName= "A",
+                                    ServiceType = "Power"
+                                } },
+                Date = DateTime.Now.Date,
+                IsAll = false,
+            }, "test");
+
+            Assert.IsNotNull(result);
+           // Assert.IsTrue(result.Computed.Count() > 0);
+            Assert.IsTrue(result.Error.Any());
+        }
+
+        [TestMethod]
+        public async Task SetDateWithoutInstallDateInJson_Succeed()
+        {
+            InstallDateResultDto result = await _bl.SetInstallDate(new InstallDateDto
+            {
+                WorkOrders = new List<WorkOrderInstallDateDto> {
+                                new WorkOrderInstallDateDto {
+                                    Name = "4",
+                                    ContractName= "A",
+                                    ServiceType = "Power"
+                                } },
+                Date = DateTime.Now.Date,
+                IsAll = false,
+            }, "test");
+
+            Assert.IsNotNull(result);
+            //Assert.IsTrue(result.Computed.Count() > 0);
+            Assert.IsTrue(result.Error.Any());
+        }
+    }
+
+    public class WorkOrderInstallDateBlTest : WorkOrderInstallDateBl
+    {
+        public WorkOrderInstallDateBlTest(ApplicationDbContext context, IWorkOrderBlackOutBl blackOutBl, IMapper mapper,IMessageIntegrationEventLogService eventLogService, IKafkaHelper kafkaHelper) : base(context, blackOutBl, mapper,eventLogService, kafkaHelper)
+        {
+        }
+
+        protected override void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username, ref List<(WorkOrderModel Current, WorkOrderModel Previous)> historiesToWrite)
+        {
+            LoggerUtil.LogDebug("Add History in Test");
+        } 
+    }
+}
+


### PR DESCRIPTION
Refactor `SetInstallDate` to improve performance by optimizing in-memory processing and batching history writes.

The previous implementation suffered from several performance bottlenecks:
*   Unsafe `AsParallel()` usage with EF Core's non-thread-safe `DbContext`.
*   O(n²) `Array.Resize` operations within a loop.
*   Repeated materialization of work orders with multiple `.ToList()` calls.
*   Creating a new `DbContext` and performing `SaveChanges` for each individual history entry.

This PR addresses these by removing `AsParallel()`, using a `List<T>` for efficient collection, materializing work orders once, and implementing batched history writes with limited parallelism to reduce `DbContext` overhead and `SaveChanges` calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-e401f1bc-9533-47af-9174-88508dedf64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e401f1bc-9533-47af-9174-88508dedf64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

