### PR TITLE
Install date bulk insert

### DIFF
--- a/WorkOrderInstallDateBl.cs
+++ b/WorkOrderInstallDateBl.cs
@@ -1,4 +1,4 @@
-﻿using WFMS.WorkOrderExecution.Model;
+using WFMS.WorkOrderExecution.Model;
 using WFMS.WorkOrderExecution.Model.Dto;
 using WFMS.WorkOrderExecution.BL.Utility;
 using System.Threading.Tasks;
@@ -41,12 +41,20 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             _kafkaHelper = kafkaHelper;
         }
 
+        protected class HistoryData
+        {
+            public WorkOrderModel Current { get; set; }
+            public WorkOrderModel Previous { get; set; }
+            public string Username { get; set; }
+        }
+
         public async Task<InstallDateResultDto> SetInstallDate(InstallDateDto data,string username)
         {
             Stopwatch st = new Stopwatch();
             st.Start();
             List<InstallDateException> exceptions = new List<InstallDateException>();
-            ConcurrentBag<Task> historiesTask = new ConcurrentBag<Task>();
+            ConcurrentBag<HistoryData> historyDataList = new ConcurrentBag<HistoryData>();
+            ConcurrentBag<WorkOrderModel> computedWorkOrdersBag = new ConcurrentBag<WorkOrderModel>();
             List<WorkOrderInstallDateDto> insideBlackOutList = new List<WorkOrderInstallDateDto>();
             List<WorkOrderInstallDateDto> missingCycleRouteList = new List<WorkOrderInstallDateDto>();
 
@@ -89,8 +97,6 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 });
             }
 
-            WorkOrderModel[] computedWorkOrders = new WorkOrderModel[0];
-
             workOrders.AsParallel().ForEach(wo =>
             {
                 bool hasException = false;
@@ -107,7 +113,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
 
                     wo.InstallDate = data.Date;
 
-                    AddHistory(wo, previous, username, ref historiesTask);
+                    AddHistory(wo, previous, username, ref historyDataList);
 
                 }
                 catch (InstallDateException e)
@@ -123,8 +129,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 finally
                 {
                     if (!hasException) {
-                        Array.Resize(ref computedWorkOrders,computedWorkOrders.Length+1);
-                        computedWorkOrders[computedWorkOrders.Length - 1] = wo;
+                        computedWorkOrdersBag.Add(wo);
                     }
                         
 
@@ -132,15 +137,23 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 }
             });
 
-            await _context.SaveChangesAsync();
+            var historyDal = new HistoryDal(_context);
+            var gevBl = new WoGenericEnumValuesBl(_context);
+            var auditBl = new AuditLogBl(_context);
+            var historyBl = new HistoryBl(_context, gevBl, auditBl, historyDal, _mapper, _kafkaHelper);
 
-            Parallel.ForEachAsync(historiesTask,async (task,token) => task.Start());
+            foreach (var historyData in historyDataList)
+            {
+                historyBl.Create(historyData.Current, historyData.Previous, historyData.Username, false);
+            }
+
+            await _context.SaveChangesAsync();
             
             st.Stop();
             LoggerUtil.LogDebug($"Async Parallel Duration: {st.Elapsed.TotalSeconds}");
             return new InstallDateResultDto
             {
-                Computed = computedWorkOrders,
+                Computed = computedWorkOrdersBag.ToArray(),
                 Error = exceptions.Select(e => new InstallDateErrorDto { 
                     Name = e.WorkOrderName,
                     Message = e.Message 
@@ -165,22 +178,9 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             return result;
         }
 
-        protected virtual void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username,ref ConcurrentBag<Task> historiesTask)
+        protected virtual void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username,ref ConcurrentBag<HistoryData> historyDataList)
         {
-            Task historyTask = new Task(() =>
-            {
-                using (ApplicationDbContext taskContext = new ApplicationDbContext())
-                {
-                    HistoryBl historyBl = new HistoryBl(taskContext
-                                            , new WoGenericEnumValuesBl(taskContext)
-                                            , new AuditLogBl(taskContext)
-                                            , new HistoryDal(taskContext),_mapper, _kafkaHelper);
-
-                    historyBl.Create(current, previous, username, true);
-                }
-            });
-
-            historiesTask.Add(historyTask);
+            historyDataList.Add(new HistoryData { Current = current, Previous = previous, Username = username });
         }
     }
 }

--- a/WorkOrderInstallDateBl.cs
+++ b/WorkOrderInstallDateBl.cs
@@ -55,9 +55,6 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             List<InstallDateException> exceptions = new List<InstallDateException>();
             ConcurrentBag<HistoryData> historyDataList = new ConcurrentBag<HistoryData>();
             ConcurrentBag<WorkOrderModel> computedWorkOrdersBag = new ConcurrentBag<WorkOrderModel>();
-            List<WorkOrderInstallDateDto> insideBlackOutList = new List<WorkOrderInstallDateDto>();
-            List<WorkOrderInstallDateDto> missingCycleRouteList = new List<WorkOrderInstallDateDto>();
-
             int count = 0;
 
             IQueryable<WorkOrderModel> workOrders = _context.Set<WorkOrderModel>().AsQueryable();
@@ -79,36 +76,41 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 workOrders = workOrders.Where(x => data.WorkOrders.Select(y => y.Name).Contains(x.Name)).AsQueryable();
 
 
+            List<WorkOrderModel> workOrdersList = workOrders.ToList();
+
+            HashSet<string> insideBlackOutNames = new HashSet<string>();
+            HashSet<string> missingCycleRouteNames = new HashSet<string>();
+
             if (data.Date > DateTime.MinValue)
             {
-                workOrders.Select(x => new { x.ContractName, x.ServiceType }).Distinct().ToList().ForEach(x =>
+                workOrdersList.Select(x => new { x.ContractName, x.ServiceType }).Distinct().ToList().ForEach(x =>
                 {
                     List<NextBlackOutDto> blackouts = _blackOutBl.GetAllBlackOuts(x.ContractName, x.ServiceType, data.Date);
-                    workOrders.Where(y => y.ContractName == x.ContractName && y.ServiceType == x.ServiceType).ToList()
+                    workOrdersList.Where(y => y.ContractName == x.ContractName && y.ServiceType == x.ServiceType).ToList()
                               .ForEach(y => {
-                                  WorkOrderInstallDateDto dto = data.WorkOrders.Single(z => z.Name == y.Name);
+                                  // WorkOrderInstallDateDto dto = data.WorkOrders.Single(z => z.Name == y.Name);
 
                                   if (cycleField == null || routeField == null)
-                                      missingCycleRouteList.Add(dto);
+                                      missingCycleRouteNames.Add(y.Name);
                                   
                                   else if (ValidateBlackOut(y, blackouts,data.Date,cycleField,routeField))
-                                      insideBlackOutList.Add(dto);
+                                      insideBlackOutNames.Add(y.Name);
                               });
                 });
             }
 
-            workOrders.AsParallel().ForEach(wo =>
+            workOrdersList.AsParallel().ForEach(wo =>
             {
                 bool hasException = false;
                 try
                 {
                     WorkOrderModel previous = _mapper.Map(wo, new WorkOrderModel());
 
-                    if (missingCycleRouteList.Any(x => x.Name == wo.Name))
+                    if (missingCycleRouteNames.Contains(wo.Name))
                         throw new InstallDateException(wo.Name, $"Work Order {wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")} should have the field cycle/route");
 
                     //Important: Temp solution blackout should be in the message because the UI need it to filter the blocking exception
-                    if (insideBlackOutList.Any(x => x.Name == wo.Name))
+                    if (insideBlackOutNames.Contains(wo.Name))
                         exceptions.Add(new InstallDateException(wo.Name, $"Work Order {wo.JsonData.Get($"{workOrderIdField.Category}.{workOrderIdField.Name}")} is inside a blackout"));
 
                     wo.InstallDate = data.Date;

--- a/WorkOrderInstallDateBlTests.cs
+++ b/WorkOrderInstallDateBlTests.cs
@@ -191,6 +191,48 @@ namespace WFMS.WorkOrderExecution.Tests
             //Assert.IsTrue(result.Computed.Count() > 0);
             Assert.IsTrue(result.Error.Any());
         }
+
+        [TestMethod]
+        public async Task SetDate_Performance_1000Records()
+        {
+            int count = 1000;
+            var workOrderList = new List<WorkOrderModel>();
+            var workOrderDtos = new List<WorkOrderInstallDateDto>();
+
+            for (int i = 0; i < count; i++)
+            {
+                string name = $"WO_{i}";
+                workOrderList.Add(new WorkOrderModel
+                {
+                    Name = name,
+                    ServiceType = "Power",
+                    ContractName = "A",
+                    JsonData = JsonDocument.Parse(new { Asset = new { InstallDate = string.Empty }, WorkOrder = new { WorkOrderId = name, Cycle = "1", Route = "a" } }.ToJsonString())
+                });
+
+                workOrderDtos.Add(new WorkOrderInstallDateDto
+                {
+                    Name = name,
+                    ContractName = "A",
+                    ServiceType = "Power"
+                });
+            }
+
+            DbSet<WorkOrderModel> workOrders = InitializeMockDBSet(workOrderList.AsQueryable());
+            _context.Set<WorkOrderModel>().Returns(workOrders);
+            _context.Set<WorkOrderModel>().AsQueryable().Returns(workOrders);
+
+            InstallDateResultDto result = await _bl.SetInstallDate(new InstallDateDto
+            {
+                WorkOrders = workOrderDtos,
+                Date = DateTime.Now.Date,
+                IsAll = false,
+            }, "test");
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(count, result.Computed.Length);
+            Assert.IsFalse(result.Error.Any());
+        }
     }
 
     public class WorkOrderInstallDateBlTest : WorkOrderInstallDateBl

--- a/WorkOrderInstallDateBlTests.cs
+++ b/WorkOrderInstallDateBlTests.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -199,7 +199,7 @@ namespace WFMS.WorkOrderExecution.Tests
         {
         }
 
-        protected override void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username, ref List<(WorkOrderModel Current, WorkOrderModel Previous)> historiesToWrite)
+        protected override void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username, ref ConcurrentBag<HistoryData> historyDataList)
         {
             LoggerUtil.LogDebug("Add History in Test");
         } 


### PR DESCRIPTION
Optimize `SetInstallDate` method to improve performance by enabling bulk inserts and batch updates.

The previous implementation suffered from creating multiple database connections and performing individual inserts for each history record, preventing Entity Framework Core from batching operations. It also used `Array.Resize` inefficiently. This PR consolidates history data collection and performs a single `SaveChangesAsync` call, allowing for efficient bulk inserts, and replaces `Array.Resize` with a `ConcurrentBag`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c60adf44-280b-4224-a3fd-75afbbfe7647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c60adf44-280b-4224-a3fd-75afbbfe7647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

