### PR TITLE
History recording issue

### DIFF
--- a/WorkOrderInstallDateBl.cs
+++ b/WorkOrderInstallDateBl.cs
@@ -193,7 +193,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             historiesToWrite.Add((current, previous));
         }
 
-        private async Task WriteHistoriesBatchedAsync(List<(WorkOrderModel Current, WorkOrderModel Previous)> histories, string username)
+        protected virtual async Task WriteHistoriesBatchedAsync(List<(WorkOrderModel Current, WorkOrderModel Previous)> histories, string username)
         {
             if (histories == null || histories.Count == 0)
                 return;

--- a/WorkOrderInstallDateBlTests.cs
+++ b/WorkOrderInstallDateBlTests.cs
@@ -209,8 +209,14 @@ namespace WFMS.WorkOrderExecution.Tests
 
         protected override void AddHistory(WorkOrderModel current, WorkOrderModel previous, string username, ref List<(WorkOrderModel Current, WorkOrderModel Previous)> historiesToWrite)
         {
+            base.AddHistory(current, previous, username, ref historiesToWrite);
             LoggerUtil.LogDebug("Add History in Test");
-        } 
+        }
+
+        protected override Task WriteHistoriesBatchedAsync(List<(WorkOrderModel Current, WorkOrderModel Previous)> histories, string username)
+        {
+            return Task.CompletedTask;
+        }
     }
 }
 


### PR DESCRIPTION
Ensures `AddHistory` is called in tests and `historiesToWrite` is populated by calling the base method and allowing `WriteHistoriesBatchedAsync` to be overridden for test isolation.

The `WorkOrderInstallDateBlTest` subclass was overriding `AddHistory` without calling the base implementation, which prevented `historiesToWrite` from being populated and breakpoints in the base method from hitting. This change ensures the base `AddHistory` logic runs in tests while allowing `WriteHistoriesBatchedAsync` to be mocked to prevent actual database writes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec9fdc30-ad34-4a5e-a733-f92f8f4be16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec9fdc30-ad34-4a5e-a733-f92f8f4be16c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

