### PR TITLE
Work order mass status

### DIFF
--- a/PostProcessingBl.cs
+++ b/PostProcessingBl.cs
@@ -1,0 +1,175 @@
+﻿using AutoMapper;
+using OlameterFramework.EventBus;
+using OlameterFramework.EventBus.IntegrationEventLog;
+using OlameterFramework.OFramework.ConfigUtils;
+using OlameterFramework.OFramework.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Amazon;
+using Amazon.Runtime;
+using WFMS.WorkOrderExecution.BL.IntegrationEvents.Events;
+using WFMS.WorkOrderExecution.BL.PostProcess;
+using WFMS.WorkOrderExecution.DAL;
+using WFMS.WorkOrderExecution.Model;
+using WFMS.WorkOrderExecution.Model.Messages;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Confluent.Kafka;
+using Xamarin.Forms;
+
+namespace WFMS.WorkOrderExecution.BL.BusinessLayer
+{
+    public interface IPostProcessingBl
+    {
+        WorkOrderModel RunPostProcess(WorkOrderModel wo, string username,string token =null);
+
+        WorkOrderModel RetryPostProcess(WorkOrderModel wo, string username);
+
+        WorkOrderModel SaveAfterApproveAudit(WorkOrderModel wo, string username);
+
+        void Init(JsonDocument args);
+    }
+
+    public class PostProcessingBl : OlameterFramework.OFramework.BL.BaseCoreEntityBl<PostProcessingModel, PostProcessingDal>, IPostProcessingBl
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IHistoryBl _historyBl;
+        private readonly IAuditLogBl _auditBl;
+        public readonly IWoGenericEnumValuesBl _gevBl;
+        private readonly IMapper _mapper;
+        private readonly IMessageIntegrationEventLogService _eventLogService;
+        private readonly IWorkOrderConfig _workOrderConfig;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly AWSCredentials _awsCredentials;
+
+        public PostProcessingBl(ApplicationDbContext context, IHistoryBl historyBl, IAuditLogBl auditBl, IWoGenericEnumValuesBl gevBl,
+            IMapper mapper, IMessageIntegrationEventLogService eventLogService, IWorkOrderConfig workOrderConfig,
+            IServiceProvider serviceProvider,AWSCredentials awsCredential = null) : base(context)
+        {
+            _context = context;
+            _historyBl = historyBl;
+            _auditBl = auditBl;
+            _gevBl = gevBl;
+            _mapper = mapper;
+            _eventLogService = eventLogService;
+            _workOrderConfig = workOrderConfig;
+            _serviceProvider = serviceProvider;
+            _awsCredentials = awsCredential;
+        }
+
+        public WorkOrderModel RunPostProcess(WorkOrderModel wo, string username,string token=null)
+        {
+            WorkOrderModel updatedWo = wo;
+
+            if (updatedWo.StatusWebString == StatusWeb.Completed.ToString() || updatedWo.StatusWebString == StatusWeb.ReturnToUtility.ToString())
+            {
+                if(updatedWo.StatusWebString == StatusWeb.Completed.ToString())
+                    updatedWo = ExecuteConfiguredPostProcess(updatedWo, username, token);
+
+                if (updatedWo.PostProcessStatusString == PostProcessStatus.PostProcessingWoStillOpen.ToStringValue() && (!updatedWo.AuditMode || updatedWo.Audited))
+                {
+                    updatedWo = ExecutePostProcess(updatedWo, username);                    
+                }                
+            }
+
+            return updatedWo;
+        }
+
+        public WorkOrderModel RetryPostProcess(WorkOrderModel wo, string username)
+        {
+            if (wo.StatusWebString == StatusWeb.Completed.ToString() && wo.PostProcessStatusString == PostProcessStatus.PostProcessingEtvFail.ToStringValue() && (!wo.AuditMode || wo.Audited))
+            {
+                ExecutePostProcess(wo, username);
+            }
+
+            return wo;
+        }
+
+
+        public WorkOrderModel SaveAfterApproveAudit(WorkOrderModel wo, string username)
+        {
+            var status = _gevBl.GetOrCreate(PostProcessStatus.PostProcessingWoEtvStart.GetEnumName(), PostProcessStatus.PostProcessingWoEtvStart.ToStringValue(), andSave: true);
+            wo.PostProcessStatusId = status.Id;
+            wo.PostProcessStatusString = PostProcessStatus.PostProcessingWoEtvStart.ToStringValue();
+
+            var model = new HistoryModel
+            {
+                WorkOrder = wo,
+                TimeStamp = DateTime.UtcNow,
+                UserName = username,
+                Audits = _auditBl.CreateAuditList(wo),
+                ActivityDetailString = ActivityDetailConstants.PostProcessStatusChanged,
+                ActivityTypeString = ActivityTypeConstants.StatusChanged,
+                PostProcessingString = PostProcessStatus.PostProcessingWoEtvStart.ToStringValue()
+            };
+
+            _historyBl.Create(model, false);
+
+            return wo;
+        }
+
+        public void Init(JsonDocument args)
+        {
+            //Nothing to init
+        }
+
+        private WorkOrderModel ExecutePostProcess(WorkOrderModel wo, string username)
+        {
+            var updatedWo = SaveAfterApproveAudit(wo, username);
+            WorkOrderReadyForExportPostProcess(updatedWo);
+
+            return updatedWo;
+        }
+
+        private void WorkOrderReadyForExportPostProcess(WorkOrderModel wo)
+        {
+            if(_awsCredentials== null)
+                LoggerUtil.LogWarning("AwsCredentials is not set");
+            
+            using (AmazonS3Client client = new AmazonS3Client(_awsCredentials,
+                       RegionEndpoint.GetBySystemName(ConfigUtil.GetValue("Amazon:Region"))))
+            {
+                string bucket = ConfigUtil.GetValue("rootbucketname");
+                var woEvent = _mapper.Map<WorkOrderReadyForExportIntegrationEventModel>(wo);
+                woEvent.Model.Files = _context.Set<FileLocationModel>().Where(x => x.WorkOrder.Name == woEvent.WorkOrderId).ToList()
+                    .Select(x =>
+                    {
+                        string url = client.GetPreSignedURL(new GetPreSignedUrlRequest
+                        {
+                            BucketName = bucket,
+                            Key = x.Location,
+                            ContentType = x.FileType,
+                            Expires = DateTime.Now.AddSeconds(604800)
+                        });
+
+                        return url;
+                    }).ToList();
+                _eventLogService.Publish<WorkOrderReadyForExportIntegrationEvent>(EventAction.Update, woEvent);
+            }
+            
+        }
+
+        private WorkOrderModel ExecuteConfiguredPostProcess(WorkOrderModel wo, string username,string token=null)
+        {
+            var config = _workOrderConfig.GetWorkOrderConfig(wo);
+            LoggerUtil.LogDebug($"Run ExecuteConfigurePostProcess WorkOrder {wo.Name}:{wo.JsonData.ToJsonString()} username:{username} config:{config.ToJsonString()}");
+            foreach (var postProcess in config.PostProcess)
+            {
+                try
+                {
+                    var postProcessBl = PostProcessFactory.CreatePostProcess(_serviceProvider, postProcess.PostProcess, postProcess.Properties);
+                    postProcessBl.RunPostProcess(wo, username,token);
+                }
+                catch (Exception ex)
+                {
+                    LoggerUtil.LogError(ex, string.Format("An error occurred while executing postprocess {0}", postProcess.PostProcess));
+                }                
+            }
+
+            return wo;
+        }
+
+    }
+}

--- a/PostProcessingBl.cs
+++ b/PostProcessingBl.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using OlameterFramework.EventBus;
 using OlameterFramework.EventBus.IntegrationEventLog;
 using OlameterFramework.OFramework.ConfigUtils;
@@ -23,7 +23,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
 {
     public interface IPostProcessingBl
     {
-        WorkOrderModel RunPostProcess(WorkOrderModel wo, string username,string token =null);
+        List<WorkOrderModel> RunPostProcess(List<WorkOrderModel> workOrders, string username,string token =null);
 
         WorkOrderModel RetryPostProcess(WorkOrderModel wo, string username);
 
@@ -59,8 +59,35 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             _awsCredentials = awsCredential;
         }
 
-        public WorkOrderModel RunPostProcess(WorkOrderModel wo, string username,string token=null)
+        public List<WorkOrderModel> RunPostProcess(List<WorkOrderModel> workOrders, string username,string token=null)
         {
+            if (workOrders == null)
+            {
+                throw new ArgumentNullException(nameof(workOrders));
+            }
+
+            if (workOrders.Count == 0)
+            {
+                return new List<WorkOrderModel>();
+            }
+
+            var updatedWorkOrders = new List<WorkOrderModel>(workOrders.Count);
+
+            foreach (var workOrder in workOrders)
+            {
+                updatedWorkOrders.Add(RunPostProcessInternal(workOrder, username, token));
+            }
+
+            return updatedWorkOrders;
+        }
+
+        private WorkOrderModel RunPostProcessInternal(WorkOrderModel wo, string username,string token=null)
+        {
+            if (wo == null)
+            {
+                throw new ArgumentNullException(nameof(wo));
+            }
+
             WorkOrderModel updatedWo = wo;
 
             if (updatedWo.StatusWebString == StatusWeb.Completed.ToString() || updatedWo.StatusWebString == StatusWeb.ReturnToUtility.ToString())

--- a/WoAdminDto.cs
+++ b/WoAdminDto.cs
@@ -1,0 +1,6 @@
+﻿namespace WFMS.WorkOrderExecution.Model.Dto
+{
+    public class WoAdminDto : StatusUpdateDto
+    {
+    }
+}

--- a/WorkOrderBl.cs
+++ b/WorkOrderBl.cs
@@ -1,4 +1,4 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Dapr.Client;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -90,7 +90,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
         WorkOrderTaskModel GetFirstTaskTemplate(long workOrderId);
         WorkOrderModel AdminWorkOrder(WorkOrderModel workOrder, WoAdminDto woAdmin, string username, string token = null);
         WorkOrderModel UpdateFromEvent(WorkOrderModel workOrder, string username, bool andSave = false, DateTimeOffset? eventDate = null);
-        WorkOrderModel StatusUpdateWorkOrder(WorkOrderModel workOrder, StatusUpdateDto statusUpdate, string username, bool isAdmin = false);
+        List<WorkOrderModel> StatusUpdateWorkOrder(List<WorkOrderModel> workOrders, StatusUpdateDto statusUpdate, string username, bool isAdmin = false);
         bool SaveWorkOrdersAndAppointment(List<WorkOrderModel> workOrders, WorkOrderSchedulerModel woScheduler, string username);
     }
 
@@ -1157,7 +1157,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 throw new Exception($"WorkOrder not found");
             }
 
-            return StatusUpdateWorkOrder(workOrder, optOut, username);
+            return StatusUpdateWorkOrder(new List<WorkOrderModel> { workOrder }, optOut, username).FirstOrDefault();
         }
 
         public WorkOrderModel CSRHoldWorkOrder(WorkOrderModel workOrder, CSRHoldDto csrHold, string username)
@@ -1169,7 +1169,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
 
             if (_woStatusRules.CSRHoldWhiteList(workOrder.StatusWeb.Name))
             {
-                return StatusUpdateWorkOrder(workOrder, csrHold, username);
+                return StatusUpdateWorkOrder(new List<WorkOrderModel> { workOrder }, csrHold, username).FirstOrDefault();
             }
 
             throw new Exception($"Not allowed to set WorkOrder in CSRHold when status is: {workOrder.StatusWeb.Name}");
@@ -1182,7 +1182,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 throw new Exception($"WorkOrder not found");
             }
 
-            var updatedWo = StatusUpdateWorkOrder(workOrder, woAdmin, username, true);
+            var updatedWo = StatusUpdateWorkOrder(new List<WorkOrderModel> { workOrder }, woAdmin, username, true).FirstOrDefault();
 
             if(updatedWo != null)
             {
@@ -1193,86 +1193,144 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
             return updatedWo;
         }
 
-        public WorkOrderModel StatusUpdateWorkOrder(WorkOrderModel workOrder, StatusUpdateDto statusUpdate, string username, bool isAdmin = false)
+        public List<WorkOrderModel> StatusUpdateWorkOrder(List<WorkOrderModel> workOrders, StatusUpdateDto statusUpdate, string username, bool isAdmin = false)
         {
-            WorkOrderModel modifiedWorkOrder = null;
+            if (workOrders == null)
+            {
+                throw new ArgumentNullException(nameof(workOrders));
+            }
+
+            if (workOrders.Count == 0)
+            {
+                return new List<WorkOrderModel>();
+            }
+
+            if (workOrders.Any(workOrder => workOrder == null))
+            {
+                throw new Exception("WorkOrder not found");
+            }
+
+            var workOrderNames = workOrders.Select(workOrder => workOrder.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Distinct()
+                .ToList();
+            var currentTasksByWorkOrderName = new Dictionary<string, WorkOrderTaskModel>();
+
+            if (workOrderNames.Count > 0)
+            {
+                var currentTaskIds = _dal.DbContext.Set<WorkOrderTaskModel>()
+                    .Where(task => workOrderNames.Contains(task.WorkOrderName))
+                    .GroupBy(task => task.WorkOrderName)
+                    .Select(group => new { group.Key, TaskId = group.Max(task => task.Id) })
+                    .ToList();
+
+                if (currentTaskIds.Count > 0)
+                {
+                    var taskIds = currentTaskIds.Select(task => task.TaskId).ToList();
+                    var currentTasks = _dal.DbContext.Set<WorkOrderTaskModel>()
+                        .Where(task => taskIds.Contains(task.Id))
+                        .Include(task => task.TaskStatus)
+                        .AsNoTracking()
+                        .ToList();
+
+                    currentTasksByWorkOrderName = currentTasks.ToDictionary(task => task.WorkOrderName);
+                }
+            }
+
+            var user = _userBl.FindBy_IQueryable(x => x.UserName == username).FirstOrDefault();
+            var woWebStatusName = statusUpdate.WebStatus != null
+                ? statusUpdate.WebStatus.Name
+                : _workOrderConfig.GetCollectionItemById(Convert.ToInt64(statusUpdate.WorkOrderStatus))?.AttributesSchemas.FirstOrDefault(x => x.Key == "GUID")?.Value;
+            var statusWeb = _gevBl.GetOrCreate(StatusWeb.None.GetEnumName(), woWebStatusName, andSave: true);
+            var taskSkippedStatus = _gevBl.GetOrCreate(TaskStatus.TaskSkipped.GetEnumName(), TaskStatus.TaskSkipped.ToStringValue(), andSave: true);
+            var taskCompletedStatus = _gevBl.GetOrCreate(TaskStatus.TaskCompleted.GetEnumName(), TaskStatus.TaskCompleted.ToStringValue(), andSave: true);
+
+            var modifiedWorkOrders = new List<WorkOrderModel>(workOrders.Count);
 
             using (IDbContextTransaction transaction = _dbContext.Database.BeginTransaction())
             {
                 try
                 {
-                    var user = _userBl.FindBy_IQueryable(x => x.UserName == username).FirstOrDefault();
-                    var woWebStatusName = statusUpdate.WebStatus != null ? statusUpdate.WebStatus.Name : _workOrderConfig.GetCollectionItemById(Convert.ToInt64(statusUpdate.WorkOrderStatus))?.AttributesSchemas.FirstOrDefault(x => x.Key == "GUID")?.Value;
-                    var statusWeb = _gevBl.GetOrCreate(StatusWeb.None.GetEnumName(), woWebStatusName, andSave: true);
-                    _workOrderStatusManager.SetWorkOrderStatus(workOrder, statusWeb, isAdmin);
-                    SetWoAssignByStatus(workOrder);
-                    modifiedWorkOrder = Update(workOrder, username, true, false, isAdmin);
-
-                    //Skip current task if any
-                    var currentTask = _dal.GetAllIQueryable(x => x.Name == workOrder.Name, noTracking: true).Include(x => x.Tasks).FirstOrDefault().Tasks.OrderByDescending(x => x.Id).FirstOrDefault();
-
-                    if (currentTask != null && currentTask.TaskStatus.Name == TaskStatus.TaskNone.ToStringValue())
+                    foreach (var workOrder in workOrders)
                     {
-                        currentTask = _dal.DbContext.Set<WorkOrderTaskModel>().SingleOrDefault(x => x.Id == currentTask.Id);
-                        currentTask.Comment = statusUpdate.SkipCode;
-                        currentTask.TaskStatus = _gevBl.GetOrCreate(TaskStatus.TaskSkipped.GetEnumName(), TaskStatus.TaskSkipped.ToStringValue(), andSave: true);
-                        currentTask.CompletedBy = user != null ? user.DisplayName : "WOMS-T000000";
-                    }
+                        _workOrderStatusManager.SetWorkOrderStatus(workOrder, statusWeb, isAdmin);
+                        SetWoAssignByStatus(workOrder);
+                        var modifiedWorkOrder = Update(workOrder, username, true, false, isAdmin);
+                        modifiedWorkOrders.Add(modifiedWorkOrder);
 
-                    if(statusUpdate.TaskName != null)
-                    {
-                        //Create task                    
-                        var nextStep = new ExecutorModel.NextStepModel()
+                        if (currentTasksByWorkOrderName.TryGetValue(workOrder.Name, out var currentTask))
                         {
-                            WorkorderStatus = statusWeb.Name,
-                            TaskTemplate = new ExecutorModel.TaskModel()
+                            var currentTaskStatus = currentTask.TaskStatus?.Name ?? currentTask.TaskStatusString;
+                            if (currentTaskStatus == TaskStatus.TaskNone.ToStringValue())
                             {
-                                Name = statusUpdate.TaskName,
-                                Status = TaskStatus.TaskCompleted.ToStringValue()
+                                currentTask = _dal.DbContext.Set<WorkOrderTaskModel>().SingleOrDefault(x => x.Id == currentTask.Id);
+                                if (currentTask != null)
+                                {
+                                    currentTask.Comment = statusUpdate.SkipCode;
+                                    currentTask.TaskStatus = taskSkippedStatus;
+                                    currentTask.CompletedBy = user != null ? user.DisplayName : "WOMS-T000000";
+                                }
                             }
-                        };
+                        }
 
-                        CreateTask(workOrder, null, username, nextStep);
-                        _dal.SaveChanges();
-
-                        //Complete task
-                        var nextTask = _dal.GetAllIQueryable(x => x.Name == workOrder.Name, noTracking: true).Include(x => x.Tasks).FirstOrDefault().Tasks.OrderByDescending(x => x.Id).FirstOrDefault();
-
-                        if (nextTask != null)
+                        if (statusUpdate.TaskName != null)
                         {
-                            nextTask = _dal.DbContext.Set<WorkOrderTaskModel>().SingleOrDefault(x => x.Id == nextTask.Id);
-                            nextTask.Comment = statusUpdate.Comment;
-                            nextTask.TaskStatus = _gevBl.GetOrCreate(TaskStatus.TaskCompleted.GetEnumName(), TaskStatus.TaskCompleted.ToStringValue(), andSave: true);
-                            nextTask.CompletedBy = user != null ? user.DisplayName : "WOMS-T000000";
-
-                            ExecutorModel.NextStepModel ns = new ExecutorModel.NextStepModel()
+                            //Create task                    
+                            var nextStep = new ExecutorModel.NextStepModel()
                             {
-                                WorkorderStatus = workOrder.StatusWeb.Name,
-                                WorkorderTaskComment = statusUpdate.SkipCode
+                                WorkorderStatus = statusWeb.Name,
+                                TaskTemplate = new ExecutorModel.TaskModel()
+                                {
+                                    Name = statusUpdate.TaskName,
+                                    Status = TaskStatus.TaskCompleted.ToStringValue()
+                                }
                             };
 
-                            CreateNextTask(workOrder.Name, nextTask, username, ns);                            
-                        }
-                    }
+                            CreateTask(workOrder, null, username, nextStep);
+                            _dal.SaveChanges();
 
-                    _dal.SaveChanges();
+                            //Complete task
+                            var nextTask = _dal.GetAllIQueryable(x => x.Name == workOrder.Name, noTracking: true).Include(x => x.Tasks).FirstOrDefault()?.Tasks.OrderByDescending(x => x.Id).FirstOrDefault();
 
-                    //Create next task if it's specified
-                    if (!string.IsNullOrWhiteSpace(statusUpdate.NextTaskToCreate))
-                    {
-
-                        var nextTaskStep = new ExecutorModel.NextStepModel()
-                        {
-                            WorkorderStatus = statusWeb.Name,
-                            TaskTemplate = new ExecutorModel.TaskModel()
+                            if (nextTask != null)
                             {
-                                Name = statusUpdate.NextTaskToCreate,
-                                Status = TaskStatus.TaskNone.ToStringValue()
-                            }
-                        };
+                                nextTask = _dal.DbContext.Set<WorkOrderTaskModel>().SingleOrDefault(x => x.Id == nextTask.Id);
+                                if (nextTask != null)
+                                {
+                                    nextTask.Comment = statusUpdate.Comment;
+                                    nextTask.TaskStatus = taskCompletedStatus;
+                                    nextTask.CompletedBy = user != null ? user.DisplayName : "WOMS-T000000";
 
-                        CreateTask(modifiedWorkOrder, null, username, nextTaskStep);
+                                    ExecutorModel.NextStepModel ns = new ExecutorModel.NextStepModel()
+                                    {
+                                        WorkorderStatus = workOrder.StatusWeb.Name,
+                                        WorkorderTaskComment = statusUpdate.SkipCode
+                                    };
+
+                                    CreateNextTask(workOrder.Name, nextTask, username, ns);
+                                }
+                            }
+                        }
+
                         _dal.SaveChanges();
+
+                        //Create next task if it's specified
+                        if (!string.IsNullOrWhiteSpace(statusUpdate.NextTaskToCreate))
+                        {
+
+                            var nextTaskStep = new ExecutorModel.NextStepModel()
+                            {
+                                WorkorderStatus = statusWeb.Name,
+                                TaskTemplate = new ExecutorModel.TaskModel()
+                                {
+                                    Name = statusUpdate.NextTaskToCreate,
+                                    Status = TaskStatus.TaskNone.ToStringValue()
+                                }
+                            };
+
+                            CreateTask(modifiedWorkOrder, null, username, nextTaskStep);
+                            _dal.SaveChanges();
+                        }
                     }
 
                     transaction.Commit();
@@ -1284,7 +1342,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 }
             }
 
-            return modifiedWorkOrder;
+            return modifiedWorkOrders;
         }
 
         public WorkOrderModel ReleaseCSRHoldWorkOrder(string workOrderName, string username)

--- a/WorkOrderBl.cs
+++ b/WorkOrderBl.cs
@@ -1210,26 +1210,47 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                 throw new Exception("WorkOrder not found");
             }
 
-            var workOrderNames = workOrders.Select(workOrder => workOrder.Name)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
+            var currentTasksByWorkOrderId = new Dictionary<long, WorkOrderTaskModel>();
+            var workOrderIdsByName = new Dictionary<string, long>();
+
+            var workOrderIds = workOrders
+                .Where(workOrder => workOrder != null && workOrder.Id > 0)
+                .Select(workOrder => workOrder.Id)
                 .Distinct()
                 .ToList();
-            var currentTasksByWorkOrderName = new Dictionary<string, WorkOrderTaskModel>();
+            var missingIdNames = workOrders
+                .Where(workOrder => workOrder != null && workOrder.Id <= 0 && !string.IsNullOrWhiteSpace(workOrder.Name))
+                .Select(workOrder => workOrder.Name)
+                .Distinct()
+                .ToList();
 
-            if (workOrderNames.Count > 0)
+            if (missingIdNames.Count > 0)
             {
-                var workOrdersWithTasks = _dal.GetAllIQueryable(workOrder => workOrderNames.Contains(workOrder.Name), noTracking: true)
-                    .Include(workOrder => workOrder.Tasks)
-                    .ThenInclude(task => task.TaskStatus)
+                workOrderIdsByName = _dal.GetAllIQueryable(workOrder => missingIdNames.Contains(workOrder.Name), noTracking: true)
+                    .Select(workOrder => new { workOrder.Name, workOrder.Id })
+                    .ToDictionary(workOrder => workOrder.Name, workOrder => workOrder.Id);
+                workOrderIds.AddRange(workOrderIdsByName.Values);
+                workOrderIds = workOrderIds.Distinct().ToList();
+            }
+
+            if (workOrderIds.Count > 0)
+            {
+                var currentTaskIds = _dal.DbContext.Set<WorkOrderTaskModel>()
+                    .Where(task => workOrderIds.Contains(task.WorkOrderId))
+                    .GroupBy(task => task.WorkOrderId)
+                    .Select(group => new { group.Key, TaskId = group.Max(task => task.Id) })
                     .ToList();
 
-                foreach (var workOrder in workOrdersWithTasks)
+                if (currentTaskIds.Count > 0)
                 {
-                    var currentTask = workOrder.Tasks?.OrderByDescending(task => task.Id).FirstOrDefault();
-                    if (currentTask != null)
-                    {
-                        currentTasksByWorkOrderName[workOrder.Name] = currentTask;
-                    }
+                    var taskIds = currentTaskIds.Select(task => task.TaskId).ToList();
+                    var currentTasks = _dal.DbContext.Set<WorkOrderTaskModel>()
+                        .Where(task => taskIds.Contains(task.Id))
+                        .Include(task => task.TaskStatus)
+                        .AsNoTracking()
+                        .ToList();
+
+                    currentTasksByWorkOrderId = currentTasks.ToDictionary(task => task.WorkOrderId);
                 }
             }
 
@@ -1254,7 +1275,13 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                         var modifiedWorkOrder = Update(workOrder, username, true, false, isAdmin);
                         modifiedWorkOrders.Add(modifiedWorkOrder);
 
-                        if (currentTasksByWorkOrderName.TryGetValue(workOrder.Name, out var currentTask))
+                        var workOrderId = workOrder.Id;
+                        if (workOrderId <= 0 && !string.IsNullOrWhiteSpace(workOrder.Name))
+                        {
+                            workOrderIdsByName.TryGetValue(workOrder.Name, out workOrderId);
+                        }
+
+                        if (workOrderId > 0 && currentTasksByWorkOrderId.TryGetValue(workOrderId, out var currentTask))
                         {
                             var currentTaskStatus = currentTask.TaskStatus?.Name ?? currentTask.TaskStatusString;
                             if (currentTaskStatus == TaskStatus.TaskNone.ToStringValue())

--- a/WorkOrderBl.cs
+++ b/WorkOrderBl.cs
@@ -731,7 +731,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
                     LoggerUtil.LogWarning($"WorkOrder {existing.Name} is not allowed to be sync by {username} because it's status is {existing.StatusWeb.Name}");
                 }
 
-                updatedModel = _postProcessingBl.RunPostProcess(updatedModel, username, token);
+                updatedModel = _postProcessingBl.RunPostProcess(new List<WorkOrderModel> { updatedModel }, username, token).FirstOrDefault();
             }
 
             return updatedModel;
@@ -1186,7 +1186,7 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
 
             if(updatedWo != null)
             {
-                updatedWo = _postProcessingBl.RunPostProcess(updatedWo, username, token);
+                updatedWo = _postProcessingBl.RunPostProcess(new List<WorkOrderModel> { updatedWo }, username, token).FirstOrDefault();
                 _dbContext.SaveChanges();
             }            
 

--- a/WorkOrderBl.cs
+++ b/WorkOrderBl.cs
@@ -1218,22 +1218,18 @@ namespace WFMS.WorkOrderExecution.BL.BusinessLayer
 
             if (workOrderNames.Count > 0)
             {
-                var currentTaskIds = _dal.DbContext.Set<WorkOrderTaskModel>()
-                    .Where(task => workOrderNames.Contains(task.WorkOrderName))
-                    .GroupBy(task => task.WorkOrderName)
-                    .Select(group => new { group.Key, TaskId = group.Max(task => task.Id) })
+                var workOrdersWithTasks = _dal.GetAllIQueryable(workOrder => workOrderNames.Contains(workOrder.Name), noTracking: true)
+                    .Include(workOrder => workOrder.Tasks)
+                    .ThenInclude(task => task.TaskStatus)
                     .ToList();
 
-                if (currentTaskIds.Count > 0)
+                foreach (var workOrder in workOrdersWithTasks)
                 {
-                    var taskIds = currentTaskIds.Select(task => task.TaskId).ToList();
-                    var currentTasks = _dal.DbContext.Set<WorkOrderTaskModel>()
-                        .Where(task => taskIds.Contains(task.Id))
-                        .Include(task => task.TaskStatus)
-                        .AsNoTracking()
-                        .ToList();
-
-                    currentTasksByWorkOrderName = currentTasks.ToDictionary(task => task.WorkOrderName);
+                    var currentTask = workOrder.Tasks?.OrderByDescending(task => task.Id).FirstOrDefault();
+                    if (currentTask != null)
+                    {
+                        currentTasksByWorkOrderName[workOrder.Name] = currentTask;
+                    }
                 }
             }
 

--- a/WorkOrderModel.cs
+++ b/WorkOrderModel.cs
@@ -1,0 +1,159 @@
+﻿using GenericEnumValues.Model;
+using Microsoft.EntityFrameworkCore;
+using NetTopologySuite.Geometries;
+using OlameterFramework.DatabaseUtilities;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace WFMS.WorkOrderExecution.Model
+{
+    public class WorkOrderModel : BaseModel
+    {
+        public WorkOrderModel()
+        {
+            Versions = new List<WorkOrderVersion>();
+            Tasks = new List<WorkOrderTaskModel>();
+        }
+
+        //https://www.npgsql.org/efcore/mapping/json.html?tabs=data-annotations%2Cpoco
+        public JsonDocument JsonData { get; set; }
+
+        public DateTime CreatedOn { get; set; }
+        public string AuditorName { get; set; }
+        public bool Audited { get; set; }
+        public bool AuditMode { get; set; }
+        public bool Active { get; set; }
+        public DateTime? StartDateBlackout { get; set; }
+        public DateTime? EndDateBlackout { get; set; }
+        public int BlackoutRemainingDays { get; set; }
+        public bool MexFlag { get; set; }
+        public DateTimeOffset? CompletedOn { get; set; }
+
+        #region for internal workflow
+        public Geometry Position { get; set; }
+        public Geometry Geofence { get; set; }
+        public int PositionSRID { get; set; }
+        public string ContractName { get; set; }
+        public string ServiceType { get; set; }
+
+        public List<WorkOrderVersion> Versions { get; set; }
+
+        public List<WorkOrderTaskModel> Tasks { get; set; }
+
+        public long? TeamDispatchId { get; set; }
+        public TeamDispatchModel? TeamDispatch { get; set; }
+
+        public ICollection<FileLocationModel> FileLocations { get; set; }
+
+        public DownloadWOTracking DownloadWOTracking { get; set; }
+
+        [Comment("All work orders that are dispatched/assigned by the dispatcher will have a fsrId associated.")]
+        public string FsrName { get; set; }
+
+        public string AssignedTo { get; set; }
+
+        public DateTime? AppointmentDate { get; set; }
+        public DateTime? InstallDate { get; set; }
+
+        [Required]
+        public GenericEnumValue StatusWeb { get; set; }
+
+        public DateTimeOffset? StatusLastChange { get; set; }
+
+        [Required]
+        public GenericEnumValue PostProcessStatus { get; set; }
+
+        [Required]
+        public long StatusWebId { get; set; }
+
+        [Required] public long PostProcessStatusId { get; set; }
+        #endregion
+
+        [NotMapped] public string ContractTitle { get; set; }
+        [NotMapped] public string ContractTimeZone { get; set; }
+        [NotMapped] public override string DefaultResourceIdentifier { get => "WO"; }
+        [NotMapped] private string _statuswebString;
+        [NotMapped]
+        public string StatusWebString
+        {
+            get
+            {
+                if (StatusWeb != null)
+                {
+                    return StatusWeb.Name;
+                }
+
+                return _statuswebString;
+            }
+            set
+            {
+                _statuswebString = value;
+            }
+        }
+
+        [NotMapped]
+        //Used on update to set new wo status. Status may not change if status rules are not meet.
+        public string NewStatusWebString { get; set; }
+
+        [NotMapped] private string _postProcessStatusString;
+        [NotMapped]
+        public string PostProcessStatusString
+        {
+            get
+            {
+                if (this.PostProcessStatus != null)
+                {
+                    return PostProcessStatus.Name;
+                }
+
+                return _postProcessStatusString;
+            }
+            set
+            {
+                _postProcessStatusString = value;
+            }
+        }        
+
+        [NotMapped]
+        public bool IsInBlackOut
+        {
+            get
+            {
+                var date = DateTime.UtcNow;
+
+                return (StartDateBlackout.HasValue &&
+                EndDateBlackout.HasValue &&
+                date.Date >= StartDateBlackout.Value.Date &&
+                date.Date <= EndDateBlackout.Value.Date);
+            }
+        }
+
+        /// <summary>
+        /// this is not the same name in the json and in the destination object
+        /// </summary>
+        /// <summary>
+        /// this is not the same name in the json and in the destination object
+        /// </summary>
+        [NotMapped] public const string SRID = "SRID";
+    }
+    public static class WorkOrderFieldName{
+        public static string WorkOrderIdFN = "WorkOrderId";
+        public static string LongitudeFN = "Longitude";
+        public static string LatitudeFN = "Latitude";
+        public static string AddressFN = "Address";
+        public static string InstallDateFN = "InstallDate";
+        public static string CycleFN = "Cycle";
+        public static string RouteFN = "Route";
+        public static string CallConsentFN = "CallConsent";
+        public static string DoNotCallFN = "DoNotCall";
+        public static string CellPhoneNoFN = "CellPhoneNo";
+        public static string CustomerNameFN = "CustomerName";
+        public static string RecordTypeFN = "RecordType";
+        public static string InstallFlagFN = "InstallFlag";
+        public static string AMInclusionExclusionFN = "AMIInclusionExclusion";
+        public static string NotesFN = "CustomerCallNotes";
+    }
+}

--- a/WorkOrderModelProfile.cs
+++ b/WorkOrderModelProfile.cs
@@ -1,4 +1,4 @@
-﻿using Olameter.WFMS.WorkOrderExecution.Common.V1;
+using Olameter.WFMS.WorkOrderExecution.Common.V1;
 using OlameterFramework.OFramework.BL;
 using OlameterFramework.OFramework.ConfigUtils;
 using OlameterFramework.OFramework.Utils;
@@ -48,7 +48,6 @@ namespace WFMS.WorkOrderExecution.Model.MappingConfigurations
                 .ForPath(x => x.WorkOrderName, y => y.MapFrom(z => z.Name));
 
             CreateMap<WorkOrderModel, WorkOrderModel>()
-                .ForMember(x => x.Id, y => y.Ignore())
                 .ForMember(x => x.JsonData, y => y.MapFrom((src, des, member) => ManualMappers.FormatPhoneNumber(ManualMappers.ExternalJsonUpdate(src.JsonData,des.JsonData))))
                 .ForMember(x => x.Versions, y => y.Ignore())
                 .ForMember(x => x.PositionSRID, y => y.Ignore())

--- a/WorkOrderModelProfile.cs
+++ b/WorkOrderModelProfile.cs
@@ -1,0 +1,443 @@
+﻿using Olameter.WFMS.WorkOrderExecution.Common.V1;
+using OlameterFramework.OFramework.BL;
+using OlameterFramework.OFramework.ConfigUtils;
+using OlameterFramework.OFramework.Utils;
+using System;
+using System.Linq;
+using System.Text.Json;
+using WFMS.WorkOrderExecution.Model.Dto;
+using WFMS.WorkOrderExecution.Model.Messages;
+using SyncQueryProto = Olameter.WFMS.WorkOrderExecution.SyncQuery.V1;
+using ApiProto = Olameter.WFMS.WorkOrderExecution.API.V1;
+using Olameter.WFMS.WorkOrderExecution.InstallDate.V1;
+using System.Data;
+using Newtonsoft.Json.Linq;
+using System.Reflection;
+using Olameter.WFMS.WorkOrderExecution.Dispatch.V1;
+using System.Collections.Generic;
+using Olameter.WFMS.WorkOrderExecution.API.V1;
+using System.Text.Json.Nodes;
+
+namespace WFMS.WorkOrderExecution.Model.MappingConfigurations
+{
+    public class WorkOrderModelProfile : AutoMapperBase
+    {
+        public WorkOrderModelProfile()
+        {
+
+            CreateMap<WorkOrderInstallDateDto, WorkOrderInstallDate>()
+                .ForPath(x => x.Name, y => y.MapFrom(z => z.Name))
+                .ForPath(x => x.ContractName, y => y.MapFrom(z => z.ContractName))
+                .ForPath(x => x.ServiceType, y => y.MapFrom(z => z.ServiceType))
+                .ReverseMap()
+                .ForPath(x => x.Name, y => y.MapFrom(z => z.Name))
+                .ForPath(x => x.ContractName, y => y.MapFrom(z => z.ContractName))
+                .ForPath(x => x.ServiceType, y => y.MapFrom(z => z.ServiceType));
+
+            CreateMap<InstallDate, InstallDateDto>()
+                .ForPath(x => x.IsAll, y => y.MapFrom(z => z.All))
+                .ForPath(x => x.WorkOrders, y => y.MapFrom(z => z.WorkOrders.ToList()))
+                .ForPath(x => x.Date, y => y.MapFrom(z => z.Remove ? DateTime.MinValue : z.Date.ToDateTime().Date));
+
+            CreateMap<InstallDateResultDto, InstallDateResult>()
+                .ForPath(x => x.Error, y => y.MapFrom(z => z.Error.ToList()));
+
+            CreateMap<InstallDateError, InstallDateErrorDto>()
+                .ForPath(x => x.Name, y => y.MapFrom(z => z.WorkOrderName))
+                .ReverseMap()
+                .ForPath(x => x.WorkOrderName, y => y.MapFrom(z => z.Name));
+
+            CreateMap<WorkOrderModel, WorkOrderModel>()
+                .ForMember(x => x.Id, y => y.Ignore())
+                .ForMember(x => x.JsonData, y => y.MapFrom((src, des, member) => ManualMappers.FormatPhoneNumber(ManualMappers.ExternalJsonUpdate(src.JsonData,des.JsonData))))
+                .ForMember(x => x.Versions, y => y.Ignore())
+                .ForMember(x => x.PositionSRID, y => y.Ignore())
+                .ForMember(x => x.Position, y => y.Ignore())
+                .ForMember(x => x.Geofence, y => y.Ignore())
+                .ForMember(x => x.StatusLastChange, y => y.Ignore());
+
+            CreateMap<WorkedOrderImported, WorkOrderModel>()
+                .ForMember(p => p.ContractName, opt => opt.MapFrom((src, des, member) => src.Context?.ContractId ?? string.Empty))
+                .ForMember(p => p.ServiceType, opt => opt.MapFrom((src, des, member) => src.Context?.ServiceType ?? string.Empty))
+                .ForMember(p => p.JsonData, opt => opt.MapFrom((src, des, member) => ManualMappers.FormatPhoneNumber(JsonDocument.Parse(src.Data.ToString()))))
+                .ForPath(x => x.Active, y => y.MapFrom(z => true))
+                .ForPath(x => x.PositionSRID, y => y.MapFrom(z => GISUtilities.Srid4326))
+                .ForPath(x => x.CreatedOn, y => y.MapFrom(z => DateTime.UtcNow));
+
+            CreateMap<WorkOrderModel, WorkOrder>()
+                .ForPath(x => x.StatusWeb, y => y.MapFrom(z => z.StatusWebString))
+                .ForPath(x => x.WorkOrderName, y => y.MapFrom(z => z.Name))
+                .ForPath(x => x.AuditMode, y => y.MapFrom(z => z.AuditMode))
+                .ForPath(x => x.AppointmentDate, y => y.MapFrom(z => z.AppointmentDate.ToProtoTimestamp()))
+                .ForPath(x => x.InstallDate, y => y.MapFrom(z => z.InstallDate.ToProtoTimestamp()))
+                .ForPath(x => x.FsrName, y => y.MapFrom(z => z.FsrName))
+                .ForMember(x => x.PostProcessing, y => y.MapFrom(z => z.PostProcessStatusString))
+                .ForMember(x => x.JsonData, y => y.MapFrom((source, dest, z) => ManualMappers.FormatPhoneNumber(source.JsonData).ToJsonString()))
+                .ForPath(x => x.EventDate, y => y.MapFrom(z => z.StatusLastChange.ToProtoTimestamp()))
+                .ForMember(x => x.ContractTimeZone, y => y.MapFrom(z => z.ContractTimeZone));
+
+            CreateMap<WorkOrder, WorkOrderModel>()
+                .ForMember(x => x.StatusWeb, y => y.Ignore())
+                .ForMember(x => x.StatusWebString, y => y.MapFrom(z => z.StatusWeb))
+                .ForMember(x => x.PostProcessStatusId, y => y.Ignore())
+                //.ForMember(x => x.Position, y => y.MapFrom((source, dest, z) => source.Position != ByteString.Empty ? wkbReader.Read(source.Position.ToByteArray()) : null))
+                .ForMember(x => x.PostProcessStatusString, y => y.MapFrom(z => z.PostProcessing))
+                .ForMember(x => x.ContractName, y => y.MapFrom(z => z.ContractName))
+                .ForMember(x => x.AppointmentDate, y => y.MapFrom(z => z.AppointmentDate.ToNullableDateTime()))
+                .ForMember(x => x.Name, y => y.MapFrom(z => z.WorkOrderName))
+                .ForMember(x => x.Tasks, y => y.MapFrom((source, dest, z) => source.Tasks?.ToList()))
+                .ForMember(x => x.Versions, y => y.MapFrom((source, dest, z) => source.Versions?.ToList()))
+                .ForMember(x => x.FsrName, y => y.MapFrom(z => z.FsrName))
+                .ForMember(x => x.CreatedOn, y => y.MapFrom(z => z.CreatedOn != null ? z.CreatedOn.ToDateTime() : DateTime.UtcNow))
+                .ForMember(x => x.StartDateBlackout, y => y.MapFrom(z => z.StartDateBlackout.ToNullableDateTime()))
+                .ForMember(x => x.EndDateBlackout, y => y.MapFrom(z => z.EndDateBlackout.ToNullableDateTime()))
+                .ForMember(x => x.InstallDate, y => y.MapFrom(z => z.InstallDate.ToNullableDateTime()))
+                .ForMember(x => x.StatusWeb, y => y.MapFrom((source, dest, z) => !source.StatusWeb.IsNullOrEmpty() ? new GenericEnumValues.Model.GenericEnumValue(StatusWeb.None.GetEnumName(), source.StatusWeb, null, null, null) : new GenericEnumValues.Model.GenericEnumValue(StatusWeb.None.GetEnumName(), StatusWeb.None.ToStringValue(), null, null, null)))
+                .ForMember(x => x.JsonData, y => y.MapFrom((source, dest, z) => ManualMappers.FormatPhoneNumber(JsonDocument.Parse(source.JsonData))));
+
+            CreateMap<WorkOrderModel, WorkOrderReadyForExportIntegrationEventModel>()
+               .ForMember(x => x.WorkOrderId, y => y.MapFrom(z => z.Name))
+               .ForMember(x => x.Model, y => y.MapFrom(z => z));
+
+            CreateMap<WorkOrderModel, WorkOrderReadyForExportModel>();
+
+            CreateMap<WorkOrderAuditSummary, WorkOrderAggregate>();
+            CreateMap<WorkOrderStatistic, SyncQueryProto.WorkOrderStatistic>().ReverseMap();
+            CreateMap<WorkOrderModel,WorkOrderHelpdeskModel>().ReverseMap();
+            CreateMap<ApiProto.WorkOrderHelpDesk, WorkOrderHelpdeskModel>()
+                .ForPath(x => x.PlannedInstallDate, y => y.MapFrom(z => z.PlannedInstallDate.ToNullableDateTime()))
+                .ForPath(x => x.PhoneNumber, y => y.MapFrom(z => z.Phone))
+                .ReverseMap()
+                .ForPath(x => x.PlannedInstallDate, y => y.MapFrom(z => z.PlannedInstallDate.ToProtoTimestamp()))
+                .ForPath(x => x.Phone, y => y.MapFrom(z => z.PhoneNumber));
+            CreateMap<ApiProto.HelpDeskData, TwilioSearchDto>()
+
+                .ForPath(x => x.PlannedInstallDate, y => y.MapFrom(z => z.PlannedInstallDate.ToNullableDateTime()))
+                .ForPath(x => x.CellPhoneNo, y => y.MapFrom(z => z.Phone))
+                .ReverseMap()
+                .ForPath(x => x.PlannedInstallDate, y => y.MapFrom(z => z.PlannedInstallDate.ToProtoTimestamp()))
+                .ForPath(x => x.Phone, y => y.MapFrom(z => z.CellPhoneNo));
+
+            CreateMap<ApiProto.ListByContractRequest, LayerDataByPolygonDto>()
+                .ForMember(x => x.ContractName, y => y.MapFrom(z => z.ContractName))
+                .ForMember(x => x.InstallDateOption, y => y.MapFrom(z => z.InstallDateOption))
+                .ForMember(x => x.StartDate, y => y.MapFrom(z => z.StartDate.ToDateTime()))
+                .ForMember(x => x.EndDate, y => y.MapFrom(z => z.EndDate.ToDateTime()))
+                .ForMember(x => x.Members, y => y.Ignore())
+                .ForMember(x => x.Operators, y => y.Ignore())
+                .ForMember(x => x.Values, y => y.Ignore())
+                .ForMember(x => x.WoStatusNames, y => y.MapFrom(z => z.WoStatusNames));
+
+            CreateMap<WorkOrderModel, UpdatedWorkOrderDto>()
+                .ForMember(x => x.StatusWeb, y => y.MapFrom(z => z.StatusWebString))
+                .ForMember(x => x.WorkOrderName, y => y.MapFrom(z => z.Name))
+                .ForMember(x => x.TeamAssignTo, y => y.MapFrom(z => z.TeamDispatch != null ? z.TeamDispatch.Title : null))
+                .ForMember(x => x.Techs, y => y.MapFrom(z => ManualMappers.MapTechs(z)));
+
+            CreateMap<UpdatedWorkOrderDto, UpdatedWorkOrder>()
+                .ForMember(x => x.StatusWeb, y => y.MapFrom(z => z.StatusWeb))
+                .ForMember(x => x.WorkOrderName, y => y.MapFrom(z => z.WorkOrderName))
+                .ForMember(x => x.TeamAssignTo, y => y.MapFrom(z => z.TeamAssignTo))
+                .ForMember(x => x.Techs, y => y.MapFrom(z => z.Techs));
+
+            CreateMap<Tech, TechDto>()
+                .ForMember(x => x.FsrName, y => y.MapFrom(z => z.FsrName))
+                .ForMember(x => x.AssignedTo, y => y.MapFrom(z => z.AssignTo))
+                .ReverseMap();
+
+            CreateMap<FsrCount, FsrCountDto>()
+                .ForMember(x => x.FsrName, y => y.MapFrom(z => z.FsrName))
+                .ForMember(x => x.StatusWeb, y => y.MapFrom(z => z.StatusWeb))
+                .ForMember(x => x.Count, y => y.MapFrom(z => z.Count))
+                .ReverseMap();
+
+            CreateMap<TeamCount, TeamCountDto>()
+                .ForMember(x => x.TeamId, y => y.MapFrom(z => z.TeamId))
+                .ForMember(x => x.TeamTitle, y => y.MapFrom(z => z.TeamTitle))
+                .ForMember(x => x.StatusWeb, y => y.MapFrom(z => z.StatusWeb))
+                .ForMember(x => x.Count, y => y.MapFrom(z => z.Count))
+                .ForMember(x => x.Techs, y => y.MapFrom(z => z.Techs))
+                .ReverseMap();
+
+            CreateMap<WorkOrderModel, WorkOrderStatusChangeDto>()
+                .ForMember(x => x.WorkOrderName, y => y.MapFrom(z => z.Name))
+                .ForMember(x => x.WorkOrderStatus, y => y.MapFrom(z => z.StatusWeb.Name))
+                .ForMember(x => x.TaskName, y => y.MapFrom(z => z.Tasks.OrderBy(t => t.Id).LastOrDefault().Name))
+                .ForMember(x => x.TaskStatus, y => y.MapFrom(z => z.Tasks.OrderBy(t => t.Id).LastOrDefault().TaskStatus.Name));
+
+            CreateMap<OptOut, OptOutDto>().ReverseMap();
+
+            CreateMap<CSRHold, CSRHoldDto>().ReverseMap();
+
+            CreateMap<WoAdmin, WoAdminDto>()
+                .ForMember(x => x.NextTaskToCreate, y => y.MapFrom(z => z.TaskToCreate)).ReverseMap();
+
+        }
+}
+public static class DateTimeExtension
+{
+        public static Google.Protobuf.WellKnownTypes.Timestamp ToProtoTimestamp(this DateTime? date)
+        {
+
+            if (date.HasValue) {
+                if (date.Value.Kind != DateTimeKind.Utc)
+                    date = new DateTime(date.Value.Ticks, DateTimeKind.Utc);
+
+                return Google.Protobuf.WellKnownTypes.Timestamp.FromDateTime(date.Value); 
+            }
+
+            var timestamp = new Google.Protobuf.WellKnownTypes.Timestamp();
+            timestamp.Seconds = 0;
+
+            return timestamp;
+        }
+
+        public static Google.Protobuf.WellKnownTypes.Timestamp ToProtoTimestamp(this DateTimeOffset? date)
+        {
+
+            if (date.HasValue)
+            {
+                return ((DateTime?)date.Value.UtcDateTime).ToProtoTimestamp();
+            }
+
+            var timestamp = new Google.Protobuf.WellKnownTypes.Timestamp();
+            timestamp.Seconds = 0;
+
+            return timestamp;
+        }
+
+        public static DateTime? ToNullableDateTime(this Google.Protobuf.WellKnownTypes.Timestamp timeStamp)
+        {
+            DateTime? dateTime = null;
+
+            if (timeStamp != null)
+            {
+                var tmp = timeStamp.ToDateTime();
+
+                if(tmp.Year > 1970)
+                {
+                    dateTime = tmp; 
+                }
+            }
+
+            return dateTime;
+        }
+    }
+
+    public static class ManualMappers
+    {
+        public static List<TechDto> MapTechs(WorkOrderModel wo)
+        {
+            var techs = new List<TechDto>();
+
+            if (!string.IsNullOrEmpty(wo.FsrName))
+            {
+                techs.Add(new TechDto { FsrName = wo.FsrName, AssignedTo = wo.AssignedTo });
+            }
+            else
+            {
+                if (wo.TeamDispatch?.TeamDispatchTechs != null)
+                {
+                    foreach (var tech in wo.TeamDispatch.TeamDispatchTechs)
+                    {
+                        techs.Add(new TechDto { FsrName = tech.FsrName, AssignedTo = tech.AssignedTo });
+                    }
+                }                
+            }
+
+            return techs;
+        }
+
+        public static WorkOrderModel Map(IDataRecord row)
+        {
+            //note: same return on ola_filter in the c# Map funtion
+            var workOrder = new WorkOrderModel();
+
+            MapColumnValue(row, workOrder, nameof(workOrder.Id));
+            MapColumnValue(row, workOrder, nameof(workOrder.ContractName));
+            //TODO Revise if we need this
+            //MapColumnValue(row, workOrder, nameof(workOrder.PositionSRID));
+            MapColumnValue(row, workOrder, nameof(workOrder.JsonData));
+            MapColumnValue(row, workOrder, nameof(workOrder.FsrName));
+
+            long statusWebId = 0;
+
+            //TODO Revise if we need this
+            //MapColumnValue(row, workOrder, nameof(workOrder.StatusWebId));
+
+            //TODO Revise if we need this
+            // include this table to improve performance
+            var tmp = GetColumnValue(row, "StatusWebName"/*hardcoden in PG ola_get_work_orders_contract funct*/);
+
+            if (tmp != null)
+            {
+                try { workOrder.StatusWeb = new GenericEnumValues.Model.GenericEnumValue { Id = statusWebId, Name = Convert.ToString(tmp) }; } catch (Exception e) { LoggerUtil.LogWarning($"StatusWeb: {e.Message}"); }
+            }
+
+            MapColumnValue(row, workOrder, nameof(workOrder.Name));
+            MapColumnValue(row, workOrder, nameof(workOrder.ServiceType));
+            MapColumnValue(row, workOrder, nameof(workOrder.Active));
+            MapColumnValue(row, workOrder, nameof(workOrder.Audited));
+            MapColumnValue(row, workOrder, nameof(workOrder.AuditorName));
+            MapColumnValue(row, workOrder, nameof(workOrder.CreatedOn));
+            MapColumnValue(row, workOrder, nameof(workOrder.AssignedTo));
+            MapColumnValue(row, workOrder, nameof(workOrder.AuditMode));
+            MapColumnValue(row, workOrder, nameof(workOrder.PostProcessStatusId));
+            MapColumnValue(row, workOrder, nameof(workOrder.BlackoutRemainingDays));
+            MapColumnValue(row, workOrder, nameof(workOrder.StartDateBlackout));
+            MapColumnValue(row, workOrder, nameof(workOrder.AppointmentDate));
+            MapColumnValue(row, workOrder, nameof(workOrder.EndDateBlackout));
+            MapColumnValue(row, workOrder, nameof(workOrder.InstallDate));
+            MapColumnValue(row, workOrder, nameof(workOrder.StatusLastChange));
+            MapColumnValue(row, workOrder, nameof(workOrder.MexFlag));
+
+            return workOrder;
+        }
+
+        private static object GetColumnValue(IDataRecord row, string columnName)
+        {
+            int index;
+
+            try
+            {
+                index = row.GetOrdinal(columnName);  
+            }
+            catch (Exception e)
+            {
+                LoggerUtil.LogWarning($"{columnName}: {e.Message}");
+                return null;
+            }
+
+
+            if (row.IsDBNull(index))
+            {
+                return null;
+            }
+
+            return row.GetValue(index);
+        }
+
+        public static void MapColumnValue(IDataRecord row, WorkOrderModel workOrder, string columnName)
+        {
+            int index;
+
+            try
+            {
+                index = row.GetOrdinal(columnName);
+            }
+            catch (Exception e)
+            {
+                LoggerUtil.LogWarning($"{columnName}: {e.Message}");
+                return;
+            }            
+
+            if (row.IsDBNull(index))
+            {
+                return;
+            }
+
+            PropertyInfo propInfo;
+
+            try
+            {
+                Type type = workOrder.GetType();
+                propInfo = type.GetProperty(columnName);
+            }
+            catch (Exception e)
+            {
+                LoggerUtil.LogWarning($"{columnName}: {e.Message}");
+                return;
+            }
+
+            if(propInfo.PropertyType == typeof(Int32))
+            {
+                try { propInfo.SetValue(workOrder, Convert.ToInt32(row.GetValue(index))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(Int64))
+            {
+                try { propInfo.SetValue(workOrder, Convert.ToInt64(row.GetValue(index))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(String))
+            {
+                try { propInfo.SetValue(workOrder, Convert.ToString(row.GetValue(index))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(Boolean))
+            {
+                try { propInfo.SetValue(workOrder, Convert.ToBoolean(row.GetValue(index))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(DateTime) || propInfo.PropertyType == typeof(Nullable<DateTime>))
+            {
+                try { propInfo.SetValue(workOrder, Convert.ToDateTime(row.GetValue(index))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(DateTimeOffset) || propInfo.PropertyType == typeof(Nullable<DateTimeOffset>))
+            {
+                try { propInfo.SetValue(workOrder, new DateTimeOffset(Convert.ToDateTime(row.GetValue(index)))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else if (propInfo.PropertyType == typeof(JsonDocument))
+            {
+                try { propInfo.SetValue(workOrder, JsonDocument.Parse(Convert.ToString(row.GetValue(index)))); } catch (Exception e) { LoggerUtil.LogWarning($"Id: {e.Message}"); }
+            }
+            else
+            {
+                LoggerUtil.LogWarning($"{columnName}: No mapping for type '{propInfo.PropertyType.Name}'");
+            }
+        }
+
+        public static JsonDocument FormatPhoneNumber(JsonDocument src)
+        {
+            JsonNode source = JsonNode.Parse(src.ToJsonString());
+
+            if (source == null || source["Contact"]?["CellPhoneNo"] == null)
+            {
+                return src;
+            }
+
+            try
+            {
+                var phone = source["Contact"]["CellPhoneNo"].GetValue<string>();
+                source["Contact"]["CellPhoneNo"] = phone.Replace("-", "");
+            }
+            catch
+            {
+                return src;
+            }            
+
+            return JsonDocument.Parse(source.ToString());
+        }
+
+        public static JsonDocument ExternalJsonUpdate(JsonDocument src, JsonDocument des)
+        {
+            JToken source = JToken.Parse(src.ToJsonString());
+            JToken destination = JToken.Parse(des.ToJsonString());
+            UpdateJson(source, ref destination);
+            return JsonDocument.Parse(destination.ToString());
+        }
+
+        private static void UpdateJson(JToken source, ref JToken destination)
+        {
+            if (source.Type != JTokenType.Object || destination?.Type != JTokenType.Object)
+            {
+                destination = source;
+                return;
+            }
+
+            JObject obj1 = (JObject)source;
+            JObject obj2 = (JObject)destination;
+
+            foreach (JProperty prop1 in obj1.Properties())
+            {
+                JProperty prop2 = obj2.Property(prop1.Name);
+                var value = prop2?.Value;
+                if (prop2 == null)
+                {
+                    (destination as JObject).Add(new JProperty(prop1));
+                }
+                else
+                {
+                    UpdateJson(prop1.Value, ref value);
+                    prop2.Value = value;
+                }
+            }
+        }
+    }
+}

--- a/WorkOrderModelProfile.cs
+++ b/WorkOrderModelProfile.cs
@@ -48,6 +48,7 @@ namespace WFMS.WorkOrderExecution.Model.MappingConfigurations
                 .ForPath(x => x.WorkOrderName, y => y.MapFrom(z => z.Name));
 
             CreateMap<WorkOrderModel, WorkOrderModel>()
+                .ForMember(x => x.Id, y => y.Ignore())
                 .ForMember(x => x.JsonData, y => y.MapFrom((src, des, member) => ManualMappers.FormatPhoneNumber(ManualMappers.ExternalJsonUpdate(src.JsonData,des.JsonData))))
                 .ForMember(x => x.Versions, y => y.Ignore())
                 .ForMember(x => x.PositionSRID, y => y.Ignore())

--- a/WorkOrderService.cs
+++ b/WorkOrderService.cs
@@ -1,0 +1,749 @@
+﻿using AutoMapper;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Microsoft.AspNetCore.Authorization;
+using Olameter.WFMS.WorkOrderExecution.API.V1;
+using Olameter.WFMS.WorkOrderExecution.Common.V1;
+using OlameterFramework.Auth.Policies;
+using OlameterFramework.OFramework.ConfigUtils;
+using OlameterFramework.OFramework.gRPC;
+using OlameterFramework.OFramework.Utils;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using WFMS.WorkOrderExecution.BL.BusinessLayer;
+using WFMS.WorkOrderExecution.DAL.Move;
+using WFMS.WorkOrderExecution.Model;
+using WFMS.WorkOrderExecution.Model.Dto; 
+
+namespace WFMS.WorkOrderExecution.API.Services
+{
+    public class WorkOrderService : WorkOrderApiService.WorkOrderApiServiceBase
+    {
+        private readonly IWorkOrderBl _workOrderApiBl;
+        private readonly IWorkOrderVersionBl _workOrderVersionBl;
+        private readonly FileManagerBl _fileManagerBl;
+        private readonly IHistoryBl _historyBl;
+        private readonly IAggregateBl _auditBl;
+        private readonly IMapper _mapper;
+        private readonly string _claimName;
+        private readonly IWorkOrderSchedulerBl _workOrderSchedulerBl;
+        private readonly IWorkOrderBlackOutBl _workOrderBlackOutBl;
+        private readonly IContractBl _contractBl;
+        private readonly IReportHistoryBl _reportHistoryBl;
+        private readonly IAutoDialerBl _autoDialerBl;
+        private readonly Dictionary<string, string> _awsInfo;
+
+        public WorkOrderService(IServiceProvider serviceProvider)
+        {
+            _workOrderApiBl = serviceProvider.GetService<IWorkOrderBl>();
+            _workOrderVersionBl = serviceProvider.GetService<IWorkOrderVersionBl>();
+            _fileManagerBl = serviceProvider.GetService<FileManagerBl>();
+            _historyBl = serviceProvider.GetService<IHistoryBl>();
+            _auditBl = serviceProvider.GetService<IAggregateBl>();
+            _mapper = serviceProvider.GetService<IMapper>();
+            _workOrderSchedulerBl = serviceProvider.GetService<IWorkOrderSchedulerBl>();
+            _workOrderBlackOutBl = serviceProvider.GetService<IWorkOrderBlackOutBl>();
+            _contractBl = serviceProvider.GetService<IContractBl>();
+            _reportHistoryBl = serviceProvider.GetService<IReportHistoryBl>();
+            _autoDialerBl = serviceProvider.GetService<IAutoDialerBl>();
+
+            _claimName = ConfigUtil.GetValue("UserInfo:Identifier");
+            _awsInfo = new Dictionary<string, string>{
+                {"Key", ConfigUtil.GetValue("Aws:Key")},
+                {"Secret", ConfigUtil.GetValue("Aws:Secret")},
+                {"Region", ConfigUtil.GetValue("Aws:Region")},
+                {"UserPool", ConfigUtil.GetValue("Aws:UserPool:Wfms")}
+            };
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public async override Task GetListByContractStream(ListByContractRequest request, IServerStreamWriter<WorkOrderResponse> responseStream, ServerCallContext context)
+        {
+            OlameterFramework.OUIFramework.RequestDto filter = _mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.Filter);//TODO: here i should recieve the same objet than in the fwor... also, improve name
+            var installDateOption = System.Enum.Parse<InstallDateOption>(request.InstallDateOption);
+            var startD = request.StartDate.ToDateTime();
+            var endD = request.EndDate.ToDateTime();
+            var contract = _contractBl.GetByName(request.ContractName);
+
+            IAsyncEnumerator<WorkOrderModel> result = _workOrderApiBl.GetAllAsync(request.ContractName, startD, endD, request.WoStatusNames.ToList(), filter, installDateOption).GetAsyncEnumerator();
+
+            while (await result.MoveNextAsync())
+            {
+                var wo = _mapper.Map<WorkOrder>(result.Current);
+                wo.ContractUseCertification = contract.UseCertification;
+                wo.JsonData = _workOrderApiBl.GetRequestedFieldsOnly(request.RequestedFields.ToList(), wo.JsonData);
+                await responseStream.WriteAsync(new WorkOrderResponse { WorkOrder = wo });
+            }
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<WorkOrdersResponseList> GetListByContract(ListByContractRequest request, ServerCallContext context)
+        {
+            OlameterFramework.OUIFramework.RequestDto filter = _mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.Filter);//TODO: here i should recieve the same objet than in the fwor... also, improve name
+            var installDateOption = InstallDateOption.Custom;
+            System.Enum.TryParse<InstallDateOption>(request.InstallDateOption, out installDateOption);
+            var startD = request.StartDate.ToDateTime();
+            var endD = request.EndDate.ToDateTime();
+            var contract = _contractBl.GetByName(request.ContractName);
+            var woNcount = _workOrderApiBl.GetAll(request.ContractName, startD, endD, request.WoStatusNames.ToList(), filter, installDateOption);
+            var wos = woNcount.Select(x => _mapper.Map<WorkOrder>(x)).ToList();
+
+            foreach (var wo in wos)
+            {
+                wo.ContractUseCertification = contract.UseCertification;
+                wo.JsonData = _workOrderApiBl.GetRequestedFieldsOnly(request.RequestedFields.ToList(), wo.JsonData);
+            }
+
+            WorkOrdersResponseList result = new();
+            result.WorkOrders.AddRange(wos);
+
+            return Task.FromResult(result);
+        }
+
+        //[Authorize(Policy = AuthPolicies.ForVisitor)] Enable it when ready
+        [AllowAnonymous]
+        public override Task<ValidateAccountAndGetWorkOrderListResponse> ValidateAccountAndGetWorkOrderList(ValidateAccountAndGetWorkOrderListRequest request, ServerCallContext context)
+        {
+            OlameterFramework.OUIFramework.RequestDto filter = _mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.Filter);
+            var installDateOption = InstallDateOption.All;
+            var date = DateTime.Now;
+            var woList = _workOrderApiBl.GetAll(request.ContractName, date, date, request.WoStatusNames.ToList(), filter, installDateOption);
+            var wos = woList.Select(x => _mapper.Map<WorkOrder>(x)).ToList();
+
+            if (wos.Count == 0)
+            {
+                throw new RpcException(new Grpc.Core.Status(StatusCode.NotFound, $"Account not found"));
+            }
+
+            ValidateAccountAndGetWorkOrderListResponse result = new();
+            result.WorkOrders.AddRange(wos);
+
+            //TODO get/return token
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<TotalCountResponse> GetTotalCount(ListByContractRequest request, ServerCallContext context)
+        {
+            OlameterFramework.OUIFramework.RequestDto filter = _mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.Filter);//TODO: here i should recieve the same objet than in the fwor... also, improve name
+            var installDateOption = InstallDateOption.Custom;
+            System.Enum.TryParse<InstallDateOption>(request.InstallDateOption, out installDateOption);
+            var startD = request.StartDate.ToDateTime();
+            var endD = request.EndDate.ToDateTime();
+            long totalCount = _workOrderApiBl.GetTotalCount(request.ContractName, startD, endD, request.WoStatusNames.ToList(), filter, installDateOption);
+
+            TotalCountResponse result = new();
+            result.TotalCount = totalCount;
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<ColumnValuesResponse> GetPreFilterColumnValues(ColumnValuesRequest request, ServerCallContext context)
+        {
+            var installDateOption = InstallDateOption.Custom;
+            System.Enum.TryParse<InstallDateOption>(request.InstallDateOption, out installDateOption);
+            var startD = request.StartDate.ToDateTime();
+            var endD = request.EndDate.ToDateTime();
+            List<string> values = _workOrderApiBl.GetPreFilterColumnValues(request.ContractName, startD, endD, request.ColumnName, request.ColumnFilterValue, installDateOption);
+
+            ColumnValuesResponse result = new();
+            result.Values.AddRange(values);
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<WorkOrderResponse> Get(GetRequest request, ServerCallContext context)
+        {
+            var workorder = _workOrderApiBl.GetFirst(x => x.Name == request.WorkOrderName);
+
+            if (workorder != null)
+            {
+                var property = ConfigUtil.GetValue("UserInfo:Identifier");
+                var username = ServerCallContextUtils.GetClaimValue(context, property, _awsInfo);
+
+                if (workorder.Versions != null)
+                {
+                    workorder.Versions = workorder.Versions.OrderByDescending(x => x.CreatedOn).ToList();
+                }
+
+                _workOrderApiBl.CreateFirstTask(workorder.Name, username);
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workorder)
+            });
+        }
+
+        [AllowAnonymous]
+        public override Task<HealthzResponse> Healthz(Empty request, ServerCallContext context)
+        {
+            var (version, message) = HealthzUtils.HealthzCheck();
+
+            return Task.FromResult(new HealthzResponse
+            {
+                Message = message,
+                Version = version
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> Update(WorkOrderRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+            workOrder.Tasks = null;
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(_workOrderApiBl.Update(workOrder, username, true))
+            });
+        }
+
+        //Used in Integration Test
+        [Authorize(Policy = CustomAuthPolicies.ForIntegrationTest)]
+        public override Task<WorkOrderResponse> Create(WorkOrderRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(_workOrderApiBl.Create(workOrder, username, true))
+            });
+        }
+
+        //Used in Integration Test
+        [Authorize(Policy = CustomAuthPolicies.ForIntegrationTest)]
+        public override Task<WorkOrderResponse> Delete(WorkOrderRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(_workOrderApiBl.Delete(workOrder, "Integration Test", true))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<DeleteFileResponse> DeleteFile(DeleteFileRequest request,
+            ServerCallContext context)
+        {
+            var response = new DeleteFileResponse();
+            var fileDetails = _fileManagerBl.FindByName(request.Name);
+            try
+            {
+                response.Result = _fileManagerBl.DeleteFile(request.Name);
+            }
+            catch (Exception e)
+            {
+                LoggerUtil.LogError(e, string.Format("An exception occurred while deleting {0}", request.Name));
+                throw;
+            }
+
+            if (response.Result)
+            {
+
+                var username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+
+                var model = new HistoryModel
+                {
+                    WorkOrder = _workOrderApiBl.GetOne(x => x.JsonData.RootElement.GetProperty("WorkOrder.WorkOrderId").GetString() == fileDetails.WorkOrderName),
+                    TimeStamp = DateTime.UtcNow,
+                    UserName = username,
+                    ActivityDetailString = ActivityDetailConstants.WorkOrderUpdated,
+                    ActivityTypeString = ActivityType.ActivityTypeStatusName.ToStringValue(),
+                    PostProcessingString = PostProcessStatus.PostProcessingNone.ToStringValue()
+                };
+                _historyBl.Create(model);
+            }
+            return Task.FromResult(response);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override async Task<FilesResponse> GetFiles(FileRequest request, ServerCallContext context)
+        {
+            var workOrderFiles = await _fileManagerBl.GetWorkOrderFiles(request.WorkOrderName);
+            var workOrderFilesResponse = new FilesResponse();
+            foreach (var file in workOrderFiles)
+            {
+                workOrderFilesResponse.Files.Add(new WorkOrderFile() { FileName = file.fileName, FileUrl = file.fileUrl, Name = file.name, TimeStamp = file.createdOn.ToTimestamp() });
+            }
+            return workOrderFilesResponse;
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<HistoryResponse> GetHistoryById(HistoryRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _workOrderApiBl.FindByName(request.WorkOrderName);
+            HistoryResponse response = new HistoryResponse();
+            response.Histories.AddRange(_mapper.Map<List<History>>(_historyBl.GetHistories(x => x.WorkOrderId == workOrder.Id)));
+
+            return Task.FromResult(response);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override async Task<UploadFileResponse> UploadFile(UploadFileRequest request, ServerCallContext context)
+        {
+            var response = new UploadFileResponse();
+            LoggerUtil.LogDebug($"FileManagement, SaveFiles was called and started.");
+
+            var model = _mapper.Map<FileLocationModel>(request.File);
+
+            try
+            {
+                response.Message = await _fileManagerBl.SaveFiles(model) == FileSaveResult.Success ? "Success" : "Failure";
+            }
+            catch (Exception e)
+            {
+                LoggerUtil.LogError(e, string.Format("An error occurred while uploading {0}", request.File.FileName));
+                throw;
+            }
+
+            return await Task.FromResult(response);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<SetValidVersionResponse> SetValidVersion(SetValidVersionRequest request, ServerCallContext context)
+        {
+            WorkOrderVersion version = _workOrderVersionBl.GetOne(x => x.Name == request.VersionName);
+            WorkOrderModel workOrder = _workOrderApiBl.Get(x => x.Id == version.WorkOrderId);
+            version.WorkOrderName = workOrder.Name;
+
+            SetValidVersionResponse result = new SetValidVersionResponse
+            {
+                Version = _mapper.Map<Olameter.WFMS.WorkOrderExecution.Common.V1.Version>(_workOrderVersionBl.SetAsValid(version, true))
+            };
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<WorkOrdersAggregateResponseList> GetAggregateListByContract(ListByContractRequest request, ServerCallContext context)
+        {
+            WorkOrdersAggregateResponseList result = new WorkOrdersAggregateResponseList();
+
+            result.WorkOrderAggregate.AddRange(_mapper.Map<List<WorkOrderAggregate>>(_auditBl.GetSummary(x => x.ContractName == request.ContractName)));
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrdersResponseList> RetryFailedEtv(Empty request, ServerCallContext context)
+        {
+            var username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+            WorkOrdersResponseList result = new WorkOrdersResponseList();
+            result.WorkOrders.AddRange(_workOrderApiBl.RetryFailedPostProcess(username).Select(x => _mapper.Map<WorkOrder>(x)));
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public async override Task<CalculateBlackOutResponse> CalculateBlackOut(CalculateBlackOutRequest request, ServerCallContext context)
+        {
+            CalculateBlackOutResponse result = new CalculateBlackOutResponse();
+            DateTime date = request.CalculationDate.ToDateTime();
+
+            try
+            {
+                _workOrderBlackOutBl.CalculateProcessBlackOutAsync(date, request.ContractNames.ToList());
+                result.Result = true;
+            }
+            catch (Exception e)
+            {
+                var formatedDate = date.ToString("yyyy/MM/dd");
+                LoggerUtil.LogError(e, string.Format("An error occurred while calculating blackout for {0}", formatedDate));
+                result.Result = false;
+            }
+
+            return result;
+        }
+
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderSchedulerResponse> CreateScheduler(WorkOrderSchedulerRequest request, ServerCallContext context)
+        {
+            WorkOrderSchedulerModel model = _mapper.Map<WorkOrderSchedulerModel>(request.WorkOrderScheduler);
+
+            return Task.FromResult(new WorkOrderSchedulerResponse
+            {
+                WorkOrderScheduler = _mapper.Map<WorkOrderScheduler>(_workOrderSchedulerBl.Create(model))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderSchedulerResponse> GetScheduler(WorkOrderSchedulerNameRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new WorkOrderSchedulerResponse
+            {
+                WorkOrderScheduler = _mapper.Map<WorkOrderScheduler>(_workOrderSchedulerBl.Get(x => x.Name == request.WorkOrderSchedulerName))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderSchedulerResponse> DeleteScheduler(WorkOrderSchedulerNameRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new WorkOrderSchedulerResponse
+            {
+                WorkOrderScheduler = _mapper.Map<WorkOrderScheduler>(_workOrderSchedulerBl.Delete(request.WorkOrderSchedulerName))
+            });
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<WorkOrderSchedulerListResponse> GetSchedulerByWorkOrderAndDate(GetByWorkOrderNameDateTimeRequest request, ServerCallContext context)
+        {
+            WorkOrderSchedulerListResponse result = new WorkOrderSchedulerListResponse();
+            result.WorkOrderSchedulers.AddRange(_mapper.Map<List<WorkOrderScheduler>>(_workOrderSchedulerBl.GetAll(x => x.AppointmentDate == request.Date.ToDateTime() && x.WorkOrder.Name == request.WorkOrderName)));
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<WorkOrderSchedulerListResponse> GetSchedulerListByWorkOrder(GetRequest request, ServerCallContext context)
+        {
+            WorkOrderSchedulerListResponse result = new WorkOrderSchedulerListResponse();
+            result.WorkOrderSchedulers.AddRange(_mapper.Map<List<WorkOrderScheduler>>(_workOrderSchedulerBl.GetAll(x => x.WorkOrder.Name == request.WorkOrderName)));
+
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderSchedulerResponse> UpdateScheduler(WorkOrderSchedulerRequest request, ServerCallContext context)
+        {
+            WorkOrderSchedulerModel model = _mapper.Map<WorkOrderSchedulerModel>(request.WorkOrderScheduler);
+
+            return Task.FromResult(new WorkOrderSchedulerResponse
+            {
+                WorkOrderScheduler = _mapper.Map<WorkOrderScheduler>(_workOrderSchedulerBl.Update(model))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> CancelWorkOrderAppointment(CancelWorkOrderAppointmentRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(_workOrderSchedulerBl.CancelWorkOrderAppointment(request.WorkOrderName))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> CreateWorkOrderAppointment(CreateWorkOrderAppointmentRequest request, ServerCallContext context)
+        {
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(_workOrderApiBl.CreateWorkOrderAppointment(request.WorkOrderName, username))
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> SaveAndCreateNextTask(SaveAndCreateNextTaskRequest request, ServerCallContext context)
+        {
+            WorkOrderSchedulerModel woScheduler = _mapper.Map<WorkOrderSchedulerModel>(request.WorkOrderScheduler);
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+            WorkOrderTaskModel task = workOrder.Tasks.FirstOrDefault(x => x.WorkOrderTaskName == request.CurrentTaskName);
+
+            workOrder.Tasks = null;
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+
+            if (task.TaskStatusString == Model.TaskStatus.TaskCompleted.ToString())
+            {
+                //Cancel old appointment if any
+                try { _workOrderSchedulerBl.CancelWorkOrderAppointment(workOrder.Name); } catch { }
+
+                woScheduler = _workOrderSchedulerBl.Create(woScheduler);
+            }
+
+            try
+            {
+                workOrder = _workOrderApiBl.UpdateAndCreateNextTask(workOrder, task, username);
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    if (task.TaskStatusString == Model.TaskStatus.TaskCompleted.ToString())
+                    {
+                        _workOrderSchedulerBl.Delete(woScheduler.Name);
+                    }
+                }
+                catch { }
+
+                throw;
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workOrder)
+            });
+        }
+
+        //[Authorize(Policy = CustomAuthPolicies.ForClient)] Enable it when ready
+        [AllowAnonymous]
+        public override Task<SaveWorkOrdersAndAppointmentResponse> SaveWorkOrdersAndAppointment(SaveWorkOrdersAndAppointmentRequest request, ServerCallContext context)
+        {
+            SaveWorkOrdersAndAppointmentResponse response = new SaveWorkOrdersAndAppointmentResponse();
+            WorkOrderSchedulerModel woScheduler = _mapper.Map<WorkOrderSchedulerModel>(request.WorkOrderScheduler);
+            List<WorkOrderModel> workOrders = _mapper.Map<List<WorkOrderModel>>(request.WorkOrders);
+
+            if (workOrders.Count == 0 || woScheduler == null)
+            {
+                response.Result = false;
+            }
+            else
+            {
+                string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+                response.Result = _workOrderApiBl.SaveWorkOrdersAndAppointment(workOrders, woScheduler, username);
+            }
+
+            return Task.FromResult(response);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> WorkOrderOptOut(WorkOrderOptOutRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+            OptOutDto optOut = _mapper.Map<OptOutDto>(request.OptOut);
+
+            workOrder.Tasks = null;
+
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+
+            //Cancel old appointment if any
+            try { _workOrderSchedulerBl.CancelWorkOrderAppointment(workOrder.Name); } catch { }
+
+            try
+            {
+                workOrder = _workOrderApiBl.OptOutWorkOrder(workOrder, optOut, username);
+            }
+            catch (Exception ex)
+            {
+                LoggerUtil.LogError(ex, string.Format("Failed to OptOut workorder {0}", workOrder.Name));
+                throw;
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workOrder)
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> WorkOrderCSRHold(WorkOrderCSRHoldRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+            CSRHoldDto csrHold = _mapper.Map<CSRHoldDto>(request.CsrHold);
+
+            workOrder.Tasks = null;
+
+            //TODO: Task 49832
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName);
+
+            try
+            {
+                workOrder = _workOrderApiBl.CSRHoldWorkOrder(workOrder, csrHold, username);
+            }
+            catch (Exception ex)
+            {
+                LoggerUtil.LogError(ex, string.Format("Failed to CSRHold workorder {0}", workOrder.Name));
+                throw;
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workOrder)
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> WorkOrderReleaseCSRHold(WorkOrderReleaseCSRHoldRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder;
+            //TODO: Task 49832
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName);
+
+            try
+            {
+                workOrder = _workOrderApiBl.ReleaseCSRHoldWorkOrder(request.WorkOrderName, username);
+            }
+            catch (Exception ex)
+            {
+                LoggerUtil.LogError(ex, string.Format("Failed to release CSRHold workorder {0}", request.WorkOrderName));
+                throw;
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workOrder)
+            });
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<WorkOrderResponse> WorkOrderAdmin(WorkOrderAdminRequest request, ServerCallContext context)
+        {
+            WorkOrderModel workOrder = _mapper.Map<WorkOrderModel>(request.WorkOrder);
+            WoAdminDto woAdmin = _mapper.Map<WoAdminDto>(request.WoAdmin);
+
+            workOrder.Tasks = null;
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+            string token = context.RequestHeaders.Get("authorization").Value.Split(' ')[1];
+
+            try
+            {
+                workOrder = _workOrderApiBl.AdminWorkOrder(workOrder, woAdmin, username, token);
+            }
+            catch (Exception ex)
+            {
+                LoggerUtil.LogError(ex, string.Format("Failed to Admin workorder {0}", workOrder.Name));
+                throw;
+            }
+
+            return Task.FromResult(new WorkOrderResponse
+            {
+                WorkOrder = _mapper.Map<WorkOrder>(workOrder)
+            });
+        }
+
+        public override Task<WorkOrderResponse> WorkOrderAdminMassUpdate(WorkOrderAdminMassUpdateRequest request, ServerCallContext context)
+        {
+            List<WorkOrderModel> workOrderList = _mapper.Map<List<WorkOrderModel>>(request.WorkOrders);
+            WoAdminDto woAdmin = _mapper.Map<WoAdminDto>(request.WoAdmin);
+
+            foreach (var workOrder in workOrderList)
+                workOrder.Tasks = null;
+
+            string username = ServerCallContextUtils.GetClaimValue(context, _claimName, _awsInfo);
+            string token = context.RequestHeaders.Get("authorization").Value.Split(' ')[1];
+
+            bool result = false;
+
+            try
+            {
+                result = _workOrderApiBl.AdminWorkOrderMassUpdate(workOrderList, woAdmin, username, token);
+            }
+            catch (Exception ex)
+            {
+                LoggerUtil.LogError(ex, string.Format("Failed to Admin workorders Mass Update"));
+                throw;
+            }
+
+            return base.WorkOrderAdminMassUpdate(request, context);
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override async Task GetWorkOrderForHelpDeskStream(GetWorkOrderForHelpDeskRequest request, IServerStreamWriter<GetWorkOrderForHelpDeskResponseStream> responseStream, ServerCallContext context)
+        {
+            GetWorkOrderForHelpDeskResponse response = new GetWorkOrderForHelpDeskResponse();
+            TwilioSearchDto searchDto = _mapper.Map<TwilioSearchDto>(request.Request);
+            IAsyncEnumerator<WorkOrderHelpdeskModel> result = _workOrderApiBl.GetByContractAndPhoneAsync(searchDto);
+
+            while (await result.MoveNextAsync())
+            {
+                await responseStream.WriteAsync(new GetWorkOrderForHelpDeskResponseStream { Result = _mapper.Map<WorkOrderHelpDesk>(result.Current) });
+            }
+        }
+
+        [Authorize(Policy = CustomAuthPolicies.ForWrite)]
+        public override Task<GetWorkOrderForHelpDeskResponse> GetWorkOrderForHelpDesk(GetWorkOrderForHelpDeskRequest request, ServerCallContext context)
+        {
+            GetWorkOrderForHelpDeskResponse response = new GetWorkOrderForHelpDeskResponse();
+            TwilioSearchDto searchDto = _mapper.Map<TwilioSearchDto>(request.Request);
+            IEnumerable<WorkOrderHelpdeskModel> result = _workOrderApiBl.GetByContractAndPhone(searchDto);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            response.Result.AddRange(result.Select(x => _mapper.Map<WorkOrderHelpDesk>(x)));
+            stopwatch.Stop();
+            LoggerUtil.LogDebug($"Transfer Data:{stopwatch.Elapsed.TotalSeconds}");
+            return Task.FromResult(response);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public async override Task DownloadFile(ListByContractRequest request, IServerStreamWriter<DownloadFileResponse> responseStream, ServerCallContext context)
+        {
+            OlameterFramework.OUIFramework.RequestDto filter = _mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.Filter);
+            var startD = request.StartDate.ToDateTime();
+            var endD = request.EndDate.ToDateTime();
+            var installDateOption = InstallDateOption.Custom;
+            System.Enum.TryParse<InstallDateOption>(request.InstallDateOption, out installDateOption);
+            var report = await this._workOrderApiBl.GetIFSByAssignedTo(request.ContractName, startD, endD, request.WoStatusNames.ToList(), filter, installDateOption);
+
+            byte[] byteArray = Encoding.ASCII.GetBytes(report);
+            using MemoryStream stream = new(byteArray);
+
+            var buffer = new byte[1024 * 1024]; // 1MB chunks
+
+            int bytesRead;
+            while ((bytesRead = await stream.ReadAsync(buffer)) > 0)
+            {
+                await responseStream.WriteAsync(new DownloadFileResponse
+                {
+                    File = Google.Protobuf.ByteString.CopyFrom(buffer, 0, bytesRead),
+                });
+            }
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<GetLayerDataByPolygonResponse> GetLayerDataByPolygon(GetLayerDataByPolygonRequest request, ServerCallContext context)
+        {
+            var mapped = this._mapper.Map<LayerDataByPolygonDto>(request.ContractRequest);
+            mapped.Json = request.Json;
+            OlameterFramework.OUIFramework.RequestDto dto = this._mapper.Map<OlameterFramework.OUIFramework.RequestDto>(request.ContractRequest.Filter);
+
+            List<string> membersArray = new(), operatorsArray = new(), valuesArray = new();
+
+            if (dto.IsNotNull()) ToFrameWork.ExtractFilterSP(dto.Filters, ref membersArray, ref operatorsArray, ref valuesArray);
+
+            mapped.Members = membersArray;
+            mapped.Operators = operatorsArray;
+            mapped.Values = valuesArray;
+
+            IEnumerable<string> result = this._workOrderApiBl.GetLayerDataByPolygon(mapped);
+
+            var response = new GetLayerDataByPolygonResponse();
+
+            response.WoNames.AddRange(result);
+
+            return Task.FromResult(response);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<GetReportHistoryResponse> GetReportHistory(GetReportHistoryRequest request, ServerCallContext context)
+        {
+            var result = new GetReportHistoryResponse();
+            //I have to do that because doing the join consume to much memory and time.
+            WorkOrderModel workOrder = _workOrderApiBl.GetList(x => x.Name == request.WorkOrderName, noTracking: false).Single();
+            List<ReportHistoryModel> reportHistories = _reportHistoryBl.GetList(x => x.WorkOrderId == workOrder.Id).ToList();
+            reportHistories.ForEach(rh => rh.WorkOrder = workOrder);
+            result.ReportHistory.AddRange(_mapper.Map<List<ReportHistory>>(reportHistories));
+            return Task.FromResult(result);
+        }
+
+        [Authorize(Policy = AuthPolicies.ForRead)]
+        public override Task<GetWorkOrderCallAttemptsResponse> GetWorkOrderCallAttempts(GetWorkOrderCallAttemptsRequest request, ServerCallContext context)
+        {
+            var response = new GetWorkOrderCallAttemptsResponse();
+
+            var callAttempts = _autoDialerBl.GetCallAttempts(request.WorkOrderName);
+            IEnumerable<CallAttempt> result = _mapper.Map<List<CallAttempt>>(callAttempts);
+
+            response.CallAttempts.AddRange(result);
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/WorkOrderTaskModel.cs
+++ b/WorkOrderTaskModel.cs
@@ -1,0 +1,71 @@
+﻿using GenericEnumValues.Model;
+using OlameterFramework.DatabaseUtilities;
+using System;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
+
+namespace WFMS.WorkOrderExecution.Model
+{
+    public class WorkOrderTaskModel : BaseModel
+    {
+        public override string DefaultResourceIdentifier => "WOT";
+
+        public long WorkOrderId { get; set; }
+        public WorkOrderModel WorkOrder { get; set; }
+
+        public string WorkOrderTaskName { get; set; }
+        public string WorkOrderWorkFlowTaskName { get; set; }
+
+        public string WorkOrderWorkFlowName { get; set; }
+
+        public GenericEnumValue TaskStatus { get; set; }
+
+        public DateTime CreatedOn { get; set; }
+
+        public string Comment { get; set; }
+
+        public string TaskCategoryPayroll { get; set; }
+        
+        [NotMapped] private string _taskStatusString;
+
+        [NotMapped]
+        public string TaskStatusString
+        {
+            get
+            {
+                if (TaskStatus != null)
+                {
+                    return TaskStatus.Name;
+                }
+
+                return _taskStatusString;
+            }
+            set
+            {
+                _taskStatusString = value;
+            }
+        }
+
+        [NotMapped]
+        public string ActivityDetailString { get; set; }
+
+        [NotMapped]
+        public string ActivityTypeString { get; set; }
+
+        [NotMapped]
+        public string WorkOrderName { get; set; }
+
+        [NotMapped]
+        public bool IsSuccessfull { get; set; }
+
+        [NotMapped]
+        public JsonDocument JsonData { get; set; }
+
+        [NotMapped]
+        public string StatusWebString { get; set; }
+        public DateTimeOffset EventDate { get; set; }
+        public string CompletedBy { get; set; }
+        [NotMapped] 
+        public string TaskTitle;
+    }
+}


### PR DESCRIPTION
Update `StatusUpdateWorkOrder` to accept a list of work orders and perform batched status updates.

This change optimizes mass status updates by pre-fetching current tasks and global entity values for all work orders in a single query, reducing database roundtrips and improving efficiency.

---
<a href="https://cursor.com/background-agent?bcId=bc-234515c1-ab18-4756-b935-6bd3346ce0e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-234515c1-ab18-4756-b935-6bd3346ce0e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

