### PR TITLE
Build LocationSharing trips/location REST API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**/.git
+**/.gitignore
+**/.vs
+**/.vscode
+**/bin
+**/obj
+**/*.user
+**/*.suo
+**/*.swp
+Dockerfile*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+bin/
+obj/
+.vs/
+.vscode/
+*.user
+*.suo
+*.swp
+*.log

--- a/LocationSharing.sln
+++ b/LocationSharing.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LocationSharing.Api", "src\LocationSharing.Api\LocationSharing.Api.csproj", "{29539852-54F0-4E27-8121-B7930D497A95}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{29539852-54F0-4E27-8121-B7930D497A95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29539852-54F0-4E27-8121-B7930D497A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29539852-54F0-4E27-8121-B7930D497A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29539852-54F0-4E27-8121-B7930D497A95}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,411 @@
+# LocationSharing Trips API (.NET 10)
+
+Production-ready REST API for temporary location sharing in Trips.
+
+## Tech Stack
+
+- ASP.NET Core Web API (.NET 10)
+- Entity Framework Core + Npgsql provider
+- PostgreSQL
+- Swagger/OpenAPI
+- Docker Compose (API + Postgres)
+
+## Project Structure
+
+```text
+LocationSharing.sln
+docker-compose.yml
+src/
+  LocationSharing.Api/
+    Controllers/
+    Contracts/
+      Requests/
+      Responses/
+      Validation/
+    Data/
+    Middleware/
+    Models/
+    Utilities/
+    Dockerfile
+    Program.cs
+```
+
+## Data Model
+
+Implemented entities (all with `Id` + `PublicId`):
+
+- `Member`
+- `Trip`
+- `TripMember` (unique `(TripId, MemberId)`)
+- `MemberLocationLatest` (unique `(TripId, MemberId)`)
+- `MemberLocationHistory` (index `(TripId, MemberId, RecordedAt DESC)`)
+
+All timestamps use `DateTimeOffset`.
+
+## Error Handling
+
+- `400` validation errors:
+  - `{ "message": "The request is invalid.", "errors": { ... } }`
+- `403/404/409/500`:
+  - RFC7807 style ProblemDetails: `type`, `title`, `status`, `detail`, `instance`, `traceId`
+- Global exception middleware handles unexpected errors and returns safe `500`.
+
+## Run Locally
+
+### Option A: Docker Compose (recommended)
+
+```bash
+docker compose up --build
+```
+
+Swagger UI:
+
+- <http://localhost:8080/swagger>
+
+### Option B: Local dotnet + postgres
+
+1. Start postgres.
+2. Set connection string in `src/LocationSharing.Api/appsettings.json` or env variable:
+   - `ConnectionStrings__DefaultConnection`
+3. Run API:
+
+```bash
+dotnet run --project src/LocationSharing.Api/LocationSharing.Api.csproj
+```
+
+Swagger UI:
+
+- <http://localhost:5186/swagger>
+
+## EF Core Migrations
+
+The project is migration-ready:
+
+```bash
+dotnet tool install --global dotnet-ef
+dotnet ef migrations add InitialCreate --project src/LocationSharing.Api --startup-project src/LocationSharing.Api
+dotnet ef database update --project src/LocationSharing.Api --startup-project src/LocationSharing.Api
+```
+
+---
+
+## Sample API Responses
+
+> Note: IDs/timestamps are examples.
+
+### 1) POST `/api/members`
+
+**Success (201):**
+
+```json
+{
+  "publicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "name": "Alice Johnson",
+  "email": "alice@example.com",
+  "displayName": "Alice",
+  "imageUrl": "https://cdn.example.com/alice.jpg",
+  "createdOn": "2026-03-23T10:00:00+00:00",
+  "updatedOn": "2026-03-23T10:00:00+00:00"
+}
+```
+
+**Error (409 duplicate email):**
+
+```json
+{
+  "type": "https://httpstatuses.com/409",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "A member with this email already exists.",
+  "instance": "/api/members",
+  "traceId": "00-d7f2a8a9ec4bf8f80f6d3d9fa2f06da8-8b40f8140860d8a2-00"
+}
+```
+
+### 2) GET `/api/members/{memberPublicId}`
+
+**Success (200):**
+
+```json
+{
+  "publicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "name": "Alice Johnson",
+  "email": "alice@example.com",
+  "displayName": "Alice",
+  "imageUrl": "https://cdn.example.com/alice.jpg",
+  "createdOn": "2026-03-23T10:00:00+00:00",
+  "updatedOn": "2026-03-23T10:00:00+00:00"
+}
+```
+
+**Error (404):**
+
+```json
+{
+  "type": "https://httpstatuses.com/404",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Member not found.",
+  "instance": "/api/members/9f0a08a2-8a8f-4dfd-8d10-20c7ac3c61c3",
+  "traceId": "00-3ba5a2a2f03f0468af4b7f341dfe27a1-fef83d2462ce2d64-00"
+}
+```
+
+### 3) POST `/api/trips`
+
+**Success (201):**
+
+```json
+{
+  "publicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "name": "Airport Pickup",
+  "title": "Terminal 3 meetup",
+  "startTime": "2026-03-23T10:00:00+00:00",
+  "endTime": "2026-03-23T13:00:00+00:00",
+  "isActive": true,
+  "startLatitude": 25.2532,
+  "startLongitude": 55.3657,
+  "endLatitude": 25.2048,
+  "endLongitude": 55.2708,
+  "code": "X8P4Q2ZW",
+  "description": "Temporary sharing during airport pickup.",
+  "createdOn": "2026-03-23T10:00:00+00:00",
+  "updatedOn": "2026-03-23T10:00:00+00:00"
+}
+```
+
+**Error (400 invalid dates):**
+
+```json
+{
+  "message": "The request is invalid.",
+  "errors": {
+    "EndTime": [
+      "EndTime must be greater than StartTime."
+    ]
+  }
+}
+```
+
+### 4) GET `/api/trips/{tripPublicId}`
+
+**Success (200):**
+
+```json
+{
+  "publicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "name": "Airport Pickup",
+  "title": "Terminal 3 meetup",
+  "startTime": "2026-03-23T10:00:00+00:00",
+  "endTime": "2026-03-23T13:00:00+00:00",
+  "isActive": true,
+  "startLatitude": 25.2532,
+  "startLongitude": 55.3657,
+  "endLatitude": 25.2048,
+  "endLongitude": 55.2708,
+  "code": "X8P4Q2ZW",
+  "description": "Temporary sharing during airport pickup.",
+  "createdOn": "2026-03-23T10:00:00+00:00",
+  "updatedOn": "2026-03-23T10:00:00+00:00"
+}
+```
+
+**Error (404):**
+
+```json
+{
+  "type": "https://httpstatuses.com/404",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Trip not found.",
+  "instance": "/api/trips/2f6099d7-c7b8-4ff2-8e4f-6fda7f358170",
+  "traceId": "00-2aa75437ec9ec6a8a8818de8dd88574e-24156ab3b39cbaf1-00"
+}
+```
+
+### 5) POST `/api/trips/{tripPublicId}/end`
+
+**Success (200):**
+
+```json
+{
+  "publicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "name": "Airport Pickup",
+  "title": "Terminal 3 meetup",
+  "startTime": "2026-03-23T10:00:00+00:00",
+  "endTime": "2026-03-23T13:00:00+00:00",
+  "isActive": false,
+  "startLatitude": 25.2532,
+  "startLongitude": 55.3657,
+  "endLatitude": 25.2048,
+  "endLongitude": 55.2708,
+  "code": "X8P4Q2ZW",
+  "description": "Temporary sharing during airport pickup.",
+  "createdOn": "2026-03-23T10:00:00+00:00",
+  "updatedOn": "2026-03-23T12:35:00+00:00"
+}
+```
+
+**Error (404):**
+
+```json
+{
+  "type": "https://httpstatuses.com/404",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Trip not found.",
+  "instance": "/api/trips/5f7f9d38-1adf-4fb6-8e33-a6208b08c2f7/end",
+  "traceId": "00-1c76cf6f3408f6762670a399dfcecf17-a50a7dd07be5e3dd-00"
+}
+```
+
+### 6) POST `/api/trips/join`
+
+**Success (200):**
+
+```json
+{
+  "tripMemberPublicId": "3ecb012c-e58a-4b7d-9958-4d2cf6c1eb73",
+  "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "tripPublicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "memberName": "Alice Johnson",
+  "memberEmail": "alice@example.com",
+  "memberDisplayName": "Alice",
+  "isActive": true,
+  "joinedOn": "2026-03-23T10:05:00+00:00"
+}
+```
+
+**Error (409 already joined):**
+
+```json
+{
+  "type": "https://httpstatuses.com/409",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "Member already joined this trip.",
+  "instance": "/api/trips/join",
+  "traceId": "00-0f5bf2f66a246b90cf2c95b5e2d8a8f3-92456f45ea2e28c6-00"
+}
+```
+
+### 7) POST `/api/trips/{tripPublicId}/leave`
+
+**Success (200):**
+
+```json
+{
+  "tripMemberPublicId": "3ecb012c-e58a-4b7d-9958-4d2cf6c1eb73",
+  "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "tripPublicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "memberName": "Alice Johnson",
+  "memberEmail": "alice@example.com",
+  "memberDisplayName": "Alice",
+  "isActive": false,
+  "joinedOn": "2026-03-23T10:05:00+00:00"
+}
+```
+
+**Error (403 not active):**
+
+```json
+{
+  "type": "https://httpstatuses.com/403",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Member is not active in this trip.",
+  "instance": "/api/trips/8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d/leave",
+  "traceId": "00-a7ed5c43943cb8009a8908fe7fd59243-b6d8b1f9f230b579-00"
+}
+```
+
+### 8) POST `/api/trips/{tripPublicId}/locations`
+
+**Success (200):**
+
+```json
+{
+  "tripPublicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+  "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "recordedAt": "2026-03-23T10:06:10+00:00",
+  "updatedOn": "2026-03-23T10:06:12+00:00"
+}
+```
+
+**Error (403 trip ended/outside window):**
+
+```json
+{
+  "type": "https://httpstatuses.com/403",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Trip is not active or outside its valid time window.",
+  "instance": "/api/trips/8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d/locations",
+  "traceId": "00-f1942eb2f906f55c72e9e066dd7078f8-55cf6479b43dc959-00"
+}
+```
+
+### 9) GET `/api/trips/{tripPublicId}/locations/latest`
+
+**Success (200):**
+
+```json
+[
+  {
+    "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+    "tripPublicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+    "latitude": 25.2048,
+    "longitude": 55.2708,
+    "accuracy": 7.5,
+    "speed": 3.2,
+    "heading": 154.0,
+    "recordedAt": "2026-03-23T10:06:10+00:00",
+    "updatedOn": "2026-03-23T10:06:12+00:00"
+  }
+]
+```
+
+**Error (404):**
+
+```json
+{
+  "type": "https://httpstatuses.com/404",
+  "title": "Not Found",
+  "status": 404,
+  "detail": "Trip not found.",
+  "instance": "/api/trips/2f6099d7-c7b8-4ff2-8e4f-6fda7f358170/locations/latest",
+  "traceId": "00-68b6903b15d57f9d597acdb7d923f142-a933f4ea582f2fd0-00"
+}
+```
+
+### 10) GET `/api/trips/{tripPublicId}/members`
+
+**Success (200):**
+
+```json
+[
+  {
+    "tripMemberPublicId": "3ecb012c-e58a-4b7d-9958-4d2cf6c1eb73",
+    "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+    "tripPublicId": "8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d",
+    "memberName": "Alice Johnson",
+    "memberEmail": "alice@example.com",
+    "memberDisplayName": "Alice",
+    "isActive": true,
+    "joinedOn": "2026-03-23T10:05:00+00:00"
+  }
+]
+```
+
+**Error (403):**
+
+```json
+{
+  "type": "https://httpstatuses.com/403",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Trip is not active or outside its valid time window.",
+  "instance": "/api/trips/8b4c2f36-2ee8-49af-a14d-579f8a6d6f4d/members",
+  "traceId": "00-fba3e7f472ba9e2cf7eff661134ed2d1-05e98060705bb012-00"
+}
+```

--- a/README.md
+++ b/README.md
@@ -261,15 +261,6 @@ dotnet ef database update --project src/LocationSharing.Api --startup-project sr
 
 ### 6) POST `/api/trips/join`
 
-**Request (code-only):**
-
-```json
-{
-  "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
-  "code": "X8P4Q2ZW"
-}
-```
-
 **Success (200):**
 
 ```json

--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ dotnet ef database update --project src/LocationSharing.Api --startup-project sr
 
 ### 6) POST `/api/trips/join`
 
+**Request (code-only):**
+
+```json
+{
+  "memberPublicId": "7f8fdab1-f786-4f2b-b50b-0dc0e0f5902d",
+  "code": "X8P4Q2ZW"
+}
+```
+
 **Success (200):**
 
 ```json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: locationsharing-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: locationsharing
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d locationsharing"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: src/LocationSharing.Api/Dockerfile
+    container_name: locationsharing-api
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=locationsharing;Username=postgres;Password=postgres
+    ports:
+      - "8080:8080"
+
+volumes:
+  postgres_data:

--- a/src/LocationSharing.Api/Contracts/Requests/CreateMemberRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/CreateMemberRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class CreateMemberRequest
+{
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    [MaxLength(320)]
+    public string Email { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? DisplayName { get; set; }
+
+    [MaxLength(2048)]
+    public string? ImageUrl { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Requests/CreateTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/CreateTripRequest.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class CreateTripRequest : IValidatableObject
+{
+    [Required]
+    [MaxLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? Title { get; set; }
+
+    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
+    public bool IsActive { get; set; } = true;
+
+    [Range(-90, 90)]
+    public double? StartLatitude { get; set; }
+
+    [Range(-180, 180)]
+    public double? StartLongitude { get; set; }
+
+    [Range(-90, 90)]
+    public double? EndLatitude { get; set; }
+
+    [Range(-180, 180)]
+    public double? EndLongitude { get; set; }
+
+    [MaxLength(4000)]
+    public string? Description { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (EndTime <= StartTime)
+        {
+            yield return new ValidationResult("EndTime must be greater than StartTime.", [nameof(EndTime)]);
+        }
+    }
+}

--- a/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using LocationSharing.Api.Contracts.Validation;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class JoinTripRequest : IValidatableObject
+{
+    [NotEmptyGuid]
+    public Guid MemberPublicId { get; set; }
+
+    public Guid? TripPublicId { get; set; }
+
+    [MaxLength(16)]
+    public string? Code { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TripPublicId.HasValue && TripPublicId.Value == Guid.Empty)
+        {
+            yield return new ValidationResult(
+                "TripPublicId must be a non-empty GUID when provided.",
+                [nameof(TripPublicId)]);
+        }
+
+        if (!TripPublicId.HasValue && string.IsNullOrWhiteSpace(Code))
+        {
+            yield return new ValidationResult(
+                "Either tripPublicId or code must be provided.",
+                [nameof(TripPublicId), nameof(Code)]);
+        }
+    }
+}

--- a/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
@@ -3,12 +3,30 @@ using LocationSharing.Api.Contracts.Validation;
 
 namespace LocationSharing.Api.Contracts.Requests;
 
-public class JoinTripRequest
+public class JoinTripRequest : IValidatableObject
 {
     [NotEmptyGuid]
     public Guid MemberPublicId { get; set; }
 
-    [Required]
+    public Guid? TripPublicId { get; set; }
+
     [MaxLength(16)]
-    public string Code { get; set; } = string.Empty;
+    public string? Code { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (TripPublicId.HasValue && TripPublicId.Value == Guid.Empty)
+        {
+            yield return new ValidationResult(
+                "TripPublicId must be a non-empty GUID when provided.",
+                [nameof(TripPublicId)]);
+        }
+
+        if (!TripPublicId.HasValue && string.IsNullOrWhiteSpace(Code))
+        {
+            yield return new ValidationResult(
+                "Either tripPublicId or code must be provided.",
+                [nameof(TripPublicId), nameof(Code)]);
+        }
+    }
 }

--- a/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/JoinTripRequest.cs
@@ -3,30 +3,12 @@ using LocationSharing.Api.Contracts.Validation;
 
 namespace LocationSharing.Api.Contracts.Requests;
 
-public class JoinTripRequest : IValidatableObject
+public class JoinTripRequest
 {
     [NotEmptyGuid]
     public Guid MemberPublicId { get; set; }
 
-    public Guid? TripPublicId { get; set; }
-
+    [Required]
     [MaxLength(16)]
-    public string? Code { get; set; }
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (TripPublicId.HasValue && TripPublicId.Value == Guid.Empty)
-        {
-            yield return new ValidationResult(
-                "TripPublicId must be a non-empty GUID when provided.",
-                [nameof(TripPublicId)]);
-        }
-
-        if (!TripPublicId.HasValue && string.IsNullOrWhiteSpace(Code))
-        {
-            yield return new ValidationResult(
-                "Either tripPublicId or code must be provided.",
-                [nameof(TripPublicId), nameof(Code)]);
-        }
-    }
+    public string Code { get; set; } = string.Empty;
 }

--- a/src/LocationSharing.Api/Contracts/Requests/LeaveTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/LeaveTripRequest.cs
@@ -1,0 +1,9 @@
+using LocationSharing.Api.Contracts.Validation;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class LeaveTripRequest
+{
+    [NotEmptyGuid]
+    public Guid MemberPublicId { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Requests/PostLocationRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/PostLocationRequest.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+using LocationSharing.Api.Contracts.Validation;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class PostLocationRequest : IValidatableObject
+{
+    [NotEmptyGuid]
+    public Guid MemberPublicId { get; set; }
+
+    [Range(-90, 90)]
+    public double Latitude { get; set; }
+
+    [Range(-180, 180)]
+    public double Longitude { get; set; }
+
+    public double? Accuracy { get; set; }
+    public double? Speed { get; set; }
+    public double? Heading { get; set; }
+    public DateTimeOffset RecordedAt { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (RecordedAt == default)
+        {
+            yield return new ValidationResult("RecordedAt is required.", [nameof(RecordedAt)]);
+        }
+    }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/LocationLatestResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/LocationLatestResponse.cs
@@ -1,0 +1,14 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class LocationLatestResponse
+{
+    public Guid MemberPublicId { get; set; }
+    public Guid TripPublicId { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public double? Accuracy { get; set; }
+    public double? Speed { get; set; }
+    public double? Heading { get; set; }
+    public DateTimeOffset RecordedAt { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/LocationWriteResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/LocationWriteResponse.cs
@@ -1,0 +1,9 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class LocationWriteResponse
+{
+    public Guid TripPublicId { get; set; }
+    public Guid MemberPublicId { get; set; }
+    public DateTimeOffset RecordedAt { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/MemberResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/MemberResponse.cs
@@ -1,0 +1,12 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class MemberResponse
+{
+    public Guid PublicId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? DisplayName { get; set; }
+    public string? ImageUrl { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/TripMemberResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/TripMemberResponse.cs
@@ -1,0 +1,13 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class TripMemberResponse
+{
+    public Guid TripMemberPublicId { get; set; }
+    public Guid MemberPublicId { get; set; }
+    public Guid TripPublicId { get; set; }
+    public string MemberName { get; set; } = string.Empty;
+    public string MemberEmail { get; set; } = string.Empty;
+    public string? MemberDisplayName { get; set; }
+    public bool IsActive { get; set; }
+    public DateTimeOffset JoinedOn { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/TripResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/TripResponse.cs
@@ -1,0 +1,19 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class TripResponse
+{
+    public Guid PublicId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
+    public bool IsActive { get; set; }
+    public double? StartLatitude { get; set; }
+    public double? StartLongitude { get; set; }
+    public double? EndLatitude { get; set; }
+    public double? EndLongitude { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+}

--- a/src/LocationSharing.Api/Contracts/Responses/ValidationErrorResponse.cs
+++ b/src/LocationSharing.Api/Contracts/Responses/ValidationErrorResponse.cs
@@ -1,0 +1,7 @@
+namespace LocationSharing.Api.Contracts.Responses;
+
+public class ValidationErrorResponse
+{
+    public string Message { get; init; } = "The request is invalid.";
+    public IDictionary<string, string[]> Errors { get; init; } = new Dictionary<string, string[]>();
+}

--- a/src/LocationSharing.Api/Contracts/Validation/NotEmptyGuidAttribute.cs
+++ b/src/LocationSharing.Api/Contracts/Validation/NotEmptyGuidAttribute.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LocationSharing.Api.Contracts.Validation;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public sealed class NotEmptyGuidAttribute : ValidationAttribute
+{
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        if (value is Guid guid && guid != Guid.Empty)
+        {
+            return ValidationResult.Success;
+        }
+
+        var message = ErrorMessage ?? $"{validationContext.MemberName} must be a non-empty GUID.";
+        return new ValidationResult(message);
+    }
+}

--- a/src/LocationSharing.Api/Controllers/MembersController.cs
+++ b/src/LocationSharing.Api/Controllers/MembersController.cs
@@ -1,0 +1,91 @@
+using LocationSharing.Api.Contracts.Requests;
+using LocationSharing.Api.Contracts.Responses;
+using LocationSharing.Api.Data;
+using LocationSharing.Api.Models;
+using LocationSharing.Api.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace LocationSharing.Api.Controllers;
+
+[ApiController]
+[Route("api/members")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+public class MembersController(LocationSharingDbContext dbContext) : ControllerBase
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(MemberResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CreateMember([FromBody] CreateMemberRequest request, CancellationToken cancellationToken)
+    {
+        var emailExists = await dbContext.Members.AnyAsync(m => m.Email == request.Email, cancellationToken);
+        if (emailExists)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "A member with this email already exists.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var member = new Member
+        {
+            PublicId = Guid.NewGuid(),
+            Name = request.Name.Trim(),
+            Email = request.Email.Trim(),
+            DisplayName = request.DisplayName?.Trim(),
+            ImageUrl = request.ImageUrl?.Trim(),
+            CreatedOn = now,
+            UpdatedOn = now
+        };
+
+        dbContext.Members.Add(member);
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException exception) when (exception.InnerException is PostgresException { SqlState: "23505" })
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "A member with this email already exists.");
+        }
+
+        return CreatedAtAction(nameof(GetMemberByPublicId), new { memberPublicId = member.PublicId }, ToResponse(member));
+    }
+
+    [HttpGet("{memberPublicId:guid}")]
+    [ProducesResponseType(typeof(MemberResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetMemberByPublicId([FromRoute] Guid memberPublicId, CancellationToken cancellationToken)
+    {
+        var member = await dbContext.Members
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.PublicId == memberPublicId, cancellationToken);
+
+        if (member is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Member not found.");
+        }
+
+        return Ok(ToResponse(member));
+    }
+
+    private static MemberResponse ToResponse(Member member) =>
+        new()
+        {
+            PublicId = member.PublicId,
+            Name = member.Name,
+            Email = member.Email,
+            DisplayName = member.DisplayName,
+            ImageUrl = member.ImageUrl,
+            CreatedOn = member.CreatedOn,
+            UpdatedOn = member.UpdatedOn
+        };
+}

--- a/src/LocationSharing.Api/Controllers/TripLocationsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripLocationsController.cs
@@ -1,0 +1,167 @@
+using LocationSharing.Api.Contracts.Requests;
+using LocationSharing.Api.Contracts.Responses;
+using LocationSharing.Api.Data;
+using LocationSharing.Api.Models;
+using LocationSharing.Api.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LocationSharing.Api.Controllers;
+
+[ApiController]
+[Route("api/trips/{tripPublicId:guid}/locations")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+public class TripLocationsController(LocationSharingDbContext dbContext) : ControllerBase
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(LocationWriteResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> PostLocation(
+        [FromRoute] Guid tripPublicId,
+        [FromBody] PostLocationRequest request,
+        CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Trip is not active or outside its valid time window.");
+        }
+
+        var member = await dbContext.Members.FirstOrDefaultAsync(m => m.PublicId == request.MemberPublicId, cancellationToken);
+        if (member is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Member not found.");
+        }
+
+        var tripMember = await dbContext.TripMembers
+            .FirstOrDefaultAsync(tm => tm.TripId == trip.Id && tm.MemberId == member.Id, cancellationToken);
+        if (tripMember is null || !tripMember.IsActive)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Member is not active in this trip.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var latest = await dbContext.MemberLocationLatests
+            .FirstOrDefaultAsync(l => l.TripId == trip.Id && l.MemberId == member.Id, cancellationToken);
+
+        if (latest is null)
+        {
+            latest = new MemberLocationLatest
+            {
+                PublicId = Guid.NewGuid(),
+                TripId = trip.Id,
+                MemberId = member.Id,
+                Latitude = request.Latitude,
+                Longitude = request.Longitude,
+                Accuracy = request.Accuracy,
+                Speed = request.Speed,
+                Heading = request.Heading,
+                RecordedAt = request.RecordedAt,
+                UpdatedOn = now
+            };
+
+            dbContext.MemberLocationLatests.Add(latest);
+        }
+        else
+        {
+            latest.Latitude = request.Latitude;
+            latest.Longitude = request.Longitude;
+            latest.Accuracy = request.Accuracy;
+            latest.Speed = request.Speed;
+            latest.Heading = request.Heading;
+            latest.RecordedAt = request.RecordedAt;
+            latest.UpdatedOn = now;
+        }
+
+        var history = new MemberLocationHistory
+        {
+            PublicId = Guid.NewGuid(),
+            TripId = trip.Id,
+            MemberId = member.Id,
+            Latitude = request.Latitude,
+            Longitude = request.Longitude,
+            Accuracy = request.Accuracy,
+            Speed = request.Speed,
+            Heading = request.Heading,
+            RecordedAt = request.RecordedAt,
+            CreatedOn = now
+        };
+        dbContext.MemberLocationHistories.Add(history);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(new LocationWriteResponse
+        {
+            TripPublicId = trip.PublicId,
+            MemberPublicId = member.PublicId,
+            RecordedAt = request.RecordedAt,
+            UpdatedOn = now
+        });
+    }
+
+    [HttpGet("latest")]
+    [ProducesResponseType(typeof(IEnumerable<LocationLatestResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetLatestLocations([FromRoute] Guid tripPublicId, CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Trip is not active or outside its valid time window.");
+        }
+
+        var latestLocations = await (
+            from latest in dbContext.MemberLocationLatests.AsNoTracking()
+            join tripMember in dbContext.TripMembers.AsNoTracking()
+                on new { latest.TripId, latest.MemberId } equals new { tripMember.TripId, tripMember.MemberId }
+            join member in dbContext.Members.AsNoTracking()
+                on latest.MemberId equals member.Id
+            where latest.TripId == trip.Id && tripMember.IsActive
+            orderby latest.RecordedAt descending
+            select new LocationLatestResponse
+            {
+                MemberPublicId = member.PublicId,
+                TripPublicId = trip.PublicId,
+                Latitude = latest.Latitude,
+                Longitude = latest.Longitude,
+                Accuracy = latest.Accuracy,
+                Speed = latest.Speed,
+                Heading = latest.Heading,
+                RecordedAt = latest.RecordedAt,
+                UpdatedOn = latest.UpdatedOn
+            }).ToListAsync(cancellationToken);
+
+        return Ok(latestLocations);
+    }
+}

--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -119,14 +119,46 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
                 "Member not found.");
         }
 
-        var normalizedCode = request.Code.Trim().ToUpperInvariant();
-        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.Code == normalizedCode, cancellationToken);
+        Trip? trip = null;
+
+        if (request.TripPublicId.HasValue)
+        {
+            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == request.TripPublicId.Value, cancellationToken);
+            if (trip is null)
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Trip not found.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Code) && !string.Equals(trip.Code, request.Code.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Join code not found for the specified trip.");
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(request.Code))
+        {
+            var normalizedCode = request.Code.Trim().ToUpperInvariant();
+            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.Code == normalizedCode, cancellationToken);
+            if (trip is null)
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Join code not found.");
+            }
+        }
+
         if (trip is null)
         {
             return this.ProblemWithTrace(
                 StatusCodes.Status404NotFound,
                 "Not Found",
-                "Join code not found.");
+                "Trip not found.");
         }
 
         if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))

--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -119,46 +119,14 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
                 "Member not found.");
         }
 
-        Trip? trip = null;
-
-        if (request.TripPublicId.HasValue)
-        {
-            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == request.TripPublicId.Value, cancellationToken);
-            if (trip is null)
-            {
-                return this.ProblemWithTrace(
-                    StatusCodes.Status404NotFound,
-                    "Not Found",
-                    "Trip not found.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(request.Code) && !string.Equals(trip.Code, request.Code.Trim(), StringComparison.OrdinalIgnoreCase))
-            {
-                return this.ProblemWithTrace(
-                    StatusCodes.Status404NotFound,
-                    "Not Found",
-                    "Join code not found for the specified trip.");
-            }
-        }
-        else if (!string.IsNullOrWhiteSpace(request.Code))
-        {
-            var normalizedCode = request.Code.Trim().ToUpperInvariant();
-            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.Code == normalizedCode, cancellationToken);
-            if (trip is null)
-            {
-                return this.ProblemWithTrace(
-                    StatusCodes.Status404NotFound,
-                    "Not Found",
-                    "Join code not found.");
-            }
-        }
-
+        var normalizedCode = request.Code.Trim().ToUpperInvariant();
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.Code == normalizedCode, cancellationToken);
         if (trip is null)
         {
             return this.ProblemWithTrace(
                 StatusCodes.Status404NotFound,
                 "Not Found",
-                "Trip not found.");
+                "Join code not found.");
         }
 
         if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))

--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -1,0 +1,347 @@
+using LocationSharing.Api.Contracts.Requests;
+using LocationSharing.Api.Contracts.Responses;
+using LocationSharing.Api.Data;
+using LocationSharing.Api.Models;
+using LocationSharing.Api.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace LocationSharing.Api.Controllers;
+
+[ApiController]
+[Route("api/trips")]
+[ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+public class TripsController(LocationSharingDbContext dbContext) : ControllerBase
+{
+    [HttpPost]
+    [ProducesResponseType(typeof(TripResponse), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CreateTrip([FromBody] CreateTripRequest request, CancellationToken cancellationToken)
+    {
+        var code = await GenerateUniqueCodeAsync(cancellationToken);
+        if (code is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "Unable to generate a unique join code.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var trip = new Trip
+        {
+            PublicId = Guid.NewGuid(),
+            Name = request.Name.Trim(),
+            Title = request.Title?.Trim(),
+            StartTime = request.StartTime,
+            EndTime = request.EndTime,
+            IsActive = request.IsActive,
+            StartLatitude = request.StartLatitude,
+            StartLongitude = request.StartLongitude,
+            EndLatitude = request.EndLatitude,
+            EndLongitude = request.EndLongitude,
+            Code = code,
+            Description = request.Description?.Trim(),
+            CreatedOn = now,
+            UpdatedOn = now
+        };
+
+        dbContext.Trips.Add(trip);
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException exception) when (exception.InnerException is PostgresException { SqlState: "23505" })
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "Unable to create trip because of a uniqueness conflict. Retry request.");
+        }
+
+        return CreatedAtAction(nameof(GetTripByPublicId), new { tripPublicId = trip.PublicId }, ToTripResponse(trip));
+    }
+
+    [HttpGet("{tripPublicId:guid}")]
+    [ProducesResponseType(typeof(TripResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTripByPublicId([FromRoute] Guid tripPublicId, CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.AsNoTracking().FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        return Ok(ToTripResponse(trip));
+    }
+
+    [HttpPost("{tripPublicId:guid}/end")]
+    [ProducesResponseType(typeof(TripResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> EndTrip([FromRoute] Guid tripPublicId, CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        trip.IsActive = false;
+        trip.UpdatedOn = DateTimeOffset.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(ToTripResponse(trip));
+    }
+
+    [HttpPost("join")]
+    [ProducesResponseType(typeof(TripMemberResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> JoinTrip([FromBody] JoinTripRequest request, CancellationToken cancellationToken)
+    {
+        var member = await dbContext.Members.FirstOrDefaultAsync(m => m.PublicId == request.MemberPublicId, cancellationToken);
+        if (member is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Member not found.");
+        }
+
+        Trip? trip = null;
+
+        if (request.TripPublicId.HasValue)
+        {
+            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == request.TripPublicId.Value, cancellationToken);
+            if (trip is null)
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Trip not found.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.Code) && !string.Equals(trip.Code, request.Code.Trim(), StringComparison.OrdinalIgnoreCase))
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Join code not found for the specified trip.");
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(request.Code))
+        {
+            var normalizedCode = request.Code.Trim().ToUpperInvariant();
+            trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.Code == normalizedCode, cancellationToken);
+            if (trip is null)
+            {
+                return this.ProblemWithTrace(
+                    StatusCodes.Status404NotFound,
+                    "Not Found",
+                    "Join code not found.");
+            }
+        }
+
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Trip is not active or outside its valid time window.");
+        }
+
+        var existing = await dbContext.TripMembers
+            .Include(tm => tm.Trip)
+            .Include(tm => tm.Member)
+            .FirstOrDefaultAsync(tm => tm.TripId == trip.Id && tm.MemberId == member.Id, cancellationToken);
+
+        if (existing is not null && existing.IsActive)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "Member already joined this trip.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        if (existing is null)
+        {
+            existing = new TripMember
+            {
+                PublicId = Guid.NewGuid(),
+                MemberId = member.Id,
+                TripId = trip.Id,
+                IsActive = true,
+                JoinedOn = now,
+                Member = member,
+                Trip = trip
+            };
+            dbContext.TripMembers.Add(existing);
+        }
+        else
+        {
+            existing.IsActive = true;
+            existing.JoinedOn = now;
+        }
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException exception) when (exception.InnerException is PostgresException { SqlState: "23505" })
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status409Conflict,
+                "Conflict",
+                "Member already joined this trip.");
+        }
+        return Ok(ToTripMemberResponse(existing));
+    }
+
+    [HttpPost("{tripPublicId:guid}/leave")]
+    [ProducesResponseType(typeof(TripMemberResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> LeaveTrip(
+        [FromRoute] Guid tripPublicId,
+        [FromBody] LeaveTripRequest request,
+        CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        var member = await dbContext.Members.FirstOrDefaultAsync(m => m.PublicId == request.MemberPublicId, cancellationToken);
+        if (member is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Member not found.");
+        }
+
+        var tripMember = await dbContext.TripMembers
+            .Include(tm => tm.Member)
+            .Include(tm => tm.Trip)
+            .FirstOrDefaultAsync(tm => tm.TripId == trip.Id && tm.MemberId == member.Id, cancellationToken);
+
+        if (tripMember is null || !tripMember.IsActive)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Member is not active in this trip.");
+        }
+
+        tripMember.IsActive = false;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(ToTripMemberResponse(tripMember));
+    }
+
+    [HttpGet("{tripPublicId:guid}/members")]
+    [ProducesResponseType(typeof(IEnumerable<TripMemberResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTripMembers([FromRoute] Guid tripPublicId, CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        if (!TripRules.IsVisibleAndActive(trip, DateTimeOffset.UtcNow))
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status403Forbidden,
+                "Forbidden",
+                "Trip is not active or outside its valid time window.");
+        }
+
+        var members = await dbContext.TripMembers
+            .AsNoTracking()
+            .Where(tm => tm.TripId == trip.Id && tm.IsActive)
+            .Include(tm => tm.Member)
+            .Include(tm => tm.Trip)
+            .OrderBy(tm => tm.JoinedOn)
+            .ToListAsync(cancellationToken);
+
+        return Ok(members.Select(ToTripMemberResponse));
+    }
+
+    private async Task<string?> GenerateUniqueCodeAsync(CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            var code = TripCodeGenerator.Generate(8);
+            var exists = await dbContext.Trips.AnyAsync(t => t.Code == code, cancellationToken);
+            if (!exists)
+            {
+                return code;
+            }
+        }
+
+        return null;
+    }
+
+    private static TripResponse ToTripResponse(Trip trip) =>
+        new()
+        {
+            PublicId = trip.PublicId,
+            Name = trip.Name,
+            Title = trip.Title,
+            StartTime = trip.StartTime,
+            EndTime = trip.EndTime,
+            IsActive = trip.IsActive,
+            StartLatitude = trip.StartLatitude,
+            StartLongitude = trip.StartLongitude,
+            EndLatitude = trip.EndLatitude,
+            EndLongitude = trip.EndLongitude,
+            Code = trip.Code,
+            Description = trip.Description,
+            CreatedOn = trip.CreatedOn,
+            UpdatedOn = trip.UpdatedOn
+        };
+
+    private static TripMemberResponse ToTripMemberResponse(TripMember tripMember) =>
+        new()
+        {
+            TripMemberPublicId = tripMember.PublicId,
+            MemberPublicId = tripMember.Member.PublicId,
+            TripPublicId = tripMember.Trip.PublicId,
+            MemberName = tripMember.Member.Name,
+            MemberEmail = tripMember.Member.Email,
+            MemberDisplayName = tripMember.Member.DisplayName,
+            IsActive = tripMember.IsActive,
+            JoinedOn = tripMember.JoinedOn
+        };
+}

--- a/src/LocationSharing.Api/Data/LocationSharingDbContext.cs
+++ b/src/LocationSharing.Api/Data/LocationSharingDbContext.cs
@@ -1,0 +1,91 @@
+using LocationSharing.Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LocationSharing.Api.Data;
+
+public class LocationSharingDbContext(DbContextOptions<LocationSharingDbContext> options) : DbContext(options)
+{
+    public DbSet<Member> Members => Set<Member>();
+    public DbSet<Trip> Trips => Set<Trip>();
+    public DbSet<TripMember> TripMembers => Set<TripMember>();
+    public DbSet<MemberLocationLatest> MemberLocationLatests => Set<MemberLocationLatest>();
+    public DbSet<MemberLocationHistory> MemberLocationHistories => Set<MemberLocationHistory>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Member>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PublicId).IsUnique();
+            entity.HasIndex(x => x.Email).IsUnique();
+            entity.Property(x => x.Name).HasMaxLength(200).IsRequired();
+            entity.Property(x => x.Email).HasMaxLength(320).IsRequired();
+            entity.Property(x => x.DisplayName).HasMaxLength(200);
+            entity.Property(x => x.ImageUrl).HasMaxLength(2048);
+        });
+
+        modelBuilder.Entity<Trip>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PublicId).IsUnique();
+            entity.HasIndex(x => x.Code).IsUnique();
+            entity.Property(x => x.Name).HasMaxLength(200).IsRequired();
+            entity.Property(x => x.Title).HasMaxLength(200);
+            entity.Property(x => x.Code).HasMaxLength(16).IsRequired();
+            entity.Property(x => x.Description).HasMaxLength(4000);
+        });
+
+        modelBuilder.Entity<TripMember>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PublicId).IsUnique();
+            entity.HasIndex(x => new { x.TripId, x.MemberId }).IsUnique();
+
+            entity.HasOne(x => x.Member)
+                .WithMany(x => x.TripMembers)
+                .HasForeignKey(x => x.MemberId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(x => x.Trip)
+                .WithMany(x => x.TripMembers)
+                .HasForeignKey(x => x.TripId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<MemberLocationLatest>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PublicId).IsUnique();
+            entity.HasIndex(x => new { x.TripId, x.MemberId }).IsUnique();
+
+            entity.HasOne(x => x.Member)
+                .WithMany(x => x.LatestLocations)
+                .HasForeignKey(x => x.MemberId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(x => x.Trip)
+                .WithMany(x => x.LatestLocations)
+                .HasForeignKey(x => x.TripId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<MemberLocationHistory>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => x.PublicId).IsUnique();
+            entity.HasIndex(x => new { x.TripId, x.MemberId, x.RecordedAt }).IsDescending(false, false, true);
+
+            entity.HasOne(x => x.Member)
+                .WithMany(x => x.LocationHistory)
+                .HasForeignKey(x => x.MemberId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(x => x.Trip)
+                .WithMany(x => x.LocationHistory)
+                .HasForeignKey(x => x.TripId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+}

--- a/src/LocationSharing.Api/Dockerfile
+++ b/src/LocationSharing.Api/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["src/LocationSharing.Api/LocationSharing.Api.csproj", "src/LocationSharing.Api/"]
+RUN dotnet restore "src/LocationSharing.Api/LocationSharing.Api.csproj"
+
+COPY . .
+WORKDIR "/src/src/LocationSharing.Api"
+RUN dotnet publish "LocationSharing.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "LocationSharing.Api.dll"]

--- a/src/LocationSharing.Api/LocationSharing.Api.csproj
+++ b/src/LocationSharing.Api/LocationSharing.Api.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="*" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="*" />
+  </ItemGroup>
+
+</Project>

--- a/src/LocationSharing.Api/Middleware/GlobalExceptionMiddleware.cs
+++ b/src/LocationSharing.Api/Middleware/GlobalExceptionMiddleware.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LocationSharing.Api.Middleware;
+
+public class GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExceptionMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Unhandled exception for request {Path}", context.Request.Path);
+            await WriteErrorResponseAsync(context);
+        }
+    }
+
+    private static async Task WriteErrorResponseAsync(HttpContext context)
+    {
+        if (context.Response.HasStarted)
+        {
+            return;
+        }
+
+        context.Response.Clear();
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        context.Response.ContentType = "application/problem+json";
+
+        var problem = new ProblemDetails
+        {
+            Type = "https://httpstatuses.com/500",
+            Title = "Internal Server Error",
+            Status = StatusCodes.Status500InternalServerError,
+            Detail = "An unexpected error occurred.",
+            Instance = context.Request.Path
+        };
+        problem.Extensions["traceId"] = context.TraceIdentifier;
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(problem));
+    }
+}

--- a/src/LocationSharing.Api/Models/Member.cs
+++ b/src/LocationSharing.Api/Models/Member.cs
@@ -1,0 +1,17 @@
+namespace LocationSharing.Api.Models;
+
+public class Member
+{
+    public int Id { get; set; }
+    public Guid PublicId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? DisplayName { get; set; }
+    public string? ImageUrl { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+
+    public ICollection<TripMember> TripMembers { get; set; } = new List<TripMember>();
+    public ICollection<MemberLocationHistory> LocationHistory { get; set; } = new List<MemberLocationHistory>();
+    public ICollection<MemberLocationLatest> LatestLocations { get; set; } = new List<MemberLocationLatest>();
+}

--- a/src/LocationSharing.Api/Models/MemberLocationHistory.cs
+++ b/src/LocationSharing.Api/Models/MemberLocationHistory.cs
@@ -1,0 +1,19 @@
+namespace LocationSharing.Api.Models;
+
+public class MemberLocationHistory
+{
+    public int Id { get; set; }
+    public Guid PublicId { get; set; }
+    public int MemberId { get; set; }
+    public int TripId { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public double? Accuracy { get; set; }
+    public double? Speed { get; set; }
+    public double? Heading { get; set; }
+    public DateTimeOffset RecordedAt { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+
+    public Member Member { get; set; } = null!;
+    public Trip Trip { get; set; } = null!;
+}

--- a/src/LocationSharing.Api/Models/MemberLocationLatest.cs
+++ b/src/LocationSharing.Api/Models/MemberLocationLatest.cs
@@ -1,0 +1,19 @@
+namespace LocationSharing.Api.Models;
+
+public class MemberLocationLatest
+{
+    public int Id { get; set; }
+    public Guid PublicId { get; set; }
+    public int MemberId { get; set; }
+    public int TripId { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public double? Accuracy { get; set; }
+    public double? Speed { get; set; }
+    public double? Heading { get; set; }
+    public DateTimeOffset RecordedAt { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+
+    public Member Member { get; set; } = null!;
+    public Trip Trip { get; set; } = null!;
+}

--- a/src/LocationSharing.Api/Models/Trip.cs
+++ b/src/LocationSharing.Api/Models/Trip.cs
@@ -1,0 +1,24 @@
+namespace LocationSharing.Api.Models;
+
+public class Trip
+{
+    public int Id { get; set; }
+    public Guid PublicId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string? Title { get; set; }
+    public DateTimeOffset StartTime { get; set; }
+    public DateTimeOffset EndTime { get; set; }
+    public bool IsActive { get; set; }
+    public double? StartLatitude { get; set; }
+    public double? StartLongitude { get; set; }
+    public double? EndLatitude { get; set; }
+    public double? EndLongitude { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateTimeOffset CreatedOn { get; set; }
+    public DateTimeOffset UpdatedOn { get; set; }
+
+    public ICollection<TripMember> TripMembers { get; set; } = new List<TripMember>();
+    public ICollection<MemberLocationHistory> LocationHistory { get; set; } = new List<MemberLocationHistory>();
+    public ICollection<MemberLocationLatest> LatestLocations { get; set; } = new List<MemberLocationLatest>();
+}

--- a/src/LocationSharing.Api/Models/TripMember.cs
+++ b/src/LocationSharing.Api/Models/TripMember.cs
@@ -1,0 +1,14 @@
+namespace LocationSharing.Api.Models;
+
+public class TripMember
+{
+    public int Id { get; set; }
+    public Guid PublicId { get; set; }
+    public int MemberId { get; set; }
+    public int TripId { get; set; }
+    public bool IsActive { get; set; }
+    public DateTimeOffset JoinedOn { get; set; }
+
+    public Member Member { get; set; } = null!;
+    public Trip Trip { get; set; } = null!;
+}

--- a/src/LocationSharing.Api/Program.cs
+++ b/src/LocationSharing.Api/Program.cs
@@ -1,0 +1,56 @@
+using LocationSharing.Api.Contracts.Responses;
+using LocationSharing.Api.Data;
+using LocationSharing.Api.Middleware;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddProblemDetails();
+
+builder.Services.Configure<ApiBehaviorOptions>(options =>
+{
+    options.InvalidModelStateResponseFactory = context =>
+    {
+        var errors = context.ModelState
+            .Where(entry => entry.Value is { Errors.Count: > 0 })
+            .ToDictionary(
+                kvp => string.IsNullOrWhiteSpace(kvp.Key) ? "request" : kvp.Key,
+                kvp => kvp.Value!.Errors.Select(error => string.IsNullOrWhiteSpace(error.ErrorMessage)
+                        ? "The value is invalid."
+                        : error.ErrorMessage)
+                    .ToArray());
+
+        return new BadRequestObjectResult(new ValidationErrorResponse
+        {
+            Message = "The request is invalid.",
+            Errors = errors
+        });
+    };
+});
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection")
+    ?? throw new InvalidOperationException("Connection string 'DefaultConnection' was not found.");
+
+builder.Services.AddDbContext<LocationSharingDbContext>(options => options.UseNpgsql(connectionString));
+
+var app = builder.Build();
+
+app.UseMiddleware<GlobalExceptionMiddleware>();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapGet("/", () => Results.Ok(new
+{
+    service = "LocationSharing API",
+    status = "ok",
+    utcNow = DateTimeOffset.UtcNow
+}));
+
+app.MapControllers();
+
+app.Run();

--- a/src/LocationSharing.Api/Properties/launchSettings.json
+++ b/src/LocationSharing.Api/Properties/launchSettings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "LocationSharing.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5186",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/LocationSharing.Api/Utilities/ControllerProblemExtensions.cs
+++ b/src/LocationSharing.Api/Utilities/ControllerProblemExtensions.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace LocationSharing.Api.Utilities;
+
+public static class ControllerProblemExtensions
+{
+    public static ObjectResult ProblemWithTrace(
+        this ControllerBase controller,
+        int statusCode,
+        string title,
+        string detail)
+    {
+        var problem = new ProblemDetails
+        {
+            Type = $"https://httpstatuses.com/{statusCode}",
+            Title = title,
+            Status = statusCode,
+            Detail = detail,
+            Instance = controller.HttpContext.Request.Path
+        };
+
+        problem.Extensions["traceId"] = controller.HttpContext.TraceIdentifier;
+        return controller.StatusCode(statusCode, problem);
+    }
+}

--- a/src/LocationSharing.Api/Utilities/TripCodeGenerator.cs
+++ b/src/LocationSharing.Api/Utilities/TripCodeGenerator.cs
@@ -1,0 +1,22 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LocationSharing.Api.Utilities;
+
+public static class TripCodeGenerator
+{
+    private const string Alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+    public static string Generate(int length = 8)
+    {
+        var bytes = RandomNumberGenerator.GetBytes(length);
+        var builder = new StringBuilder(length);
+
+        foreach (var value in bytes)
+        {
+            builder.Append(Alphabet[value % Alphabet.Length]);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/LocationSharing.Api/Utilities/TripRules.cs
+++ b/src/LocationSharing.Api/Utilities/TripRules.cs
@@ -1,0 +1,9 @@
+using LocationSharing.Api.Models;
+
+namespace LocationSharing.Api.Utilities;
+
+public static class TripRules
+{
+    public static bool IsVisibleAndActive(Trip trip, DateTimeOffset now) =>
+        trip.IsActive && now >= trip.StartTime && now <= trip.EndTime;
+}

--- a/src/LocationSharing.Api/appsettings.Development.json
+++ b/src/LocationSharing.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
+    }
+  }
+}

--- a/src/LocationSharing.Api/appsettings.json
+++ b/src/LocationSharing.Api/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=locationsharing;Username=postgres;Password=postgres"
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- scaffolded a full ASP.NET Core Web API project targeting .NET 10 for LocationSharing
- implemented required data model with internal `Id` + external `PublicId` for all entities
- added EF Core `DbContext` fluent configuration for all required indexes/uniqueness constraints
- implemented required REST endpoints for members, trips, join/leave, location post/upsert/history, latest locations, and trip members
- enforced core trip rules (active + current time between start/end), membership validation, and join-code flow
- trip joining supports code lookup and optional `tripPublicId + code` flow (restored previous behavior)
- added consistent error handling:
  - 400 model-validation response shape (`message` + `errors`)
  - 403/404/409/500 RFC7807-style responses with `traceId`
  - global exception middleware + logging
- enabled Swagger/OpenAPI response annotations for success and error cases
- added Docker support (`src/LocationSharing.Api/Dockerfile`) and `docker-compose.yml` for API + PostgreSQL
- added `README.md` with local run steps, migration commands, and success/error sample responses for each endpoint

## Notes
- The current cloud environment does not include the `dotnet` CLI, so restore/build/runtime verification could not be executed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-149b27e7-ad9f-484a-8803-9213a50b218d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-149b27e7-ad9f-484a-8803-9213a50b218d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

