### PR TITLE
Build production-ready WhatsApp-like backend API with EF Core

### DIFF
--- a/Minit.Api/Data/AppDbContext.cs
+++ b/Minit.Api/Data/AppDbContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Domain;
+using Minit.Api.Data.EntityConfigurations;
+
+namespace Minit.Api.Data;
+
+public sealed class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Contact> Contacts => Set<Contact>();
+    public DbSet<CallSession> CallSessions => Set<CallSession>();
+    public DbSet<CallParticipant> CallParticipants => Set<CallParticipant>();
+    public DbSet<MonthlyUsage> MonthlyUsages => Set<MonthlyUsage>();
+    public DbSet<UsageAdjustment> UsageAdjustments => Set<UsageAdjustment>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfiguration(new UserConfiguration());
+        modelBuilder.ApplyConfiguration(new ContactConfiguration());
+        modelBuilder.ApplyConfiguration(new CallSessionConfiguration());
+        modelBuilder.ApplyConfiguration(new CallParticipantConfiguration());
+        modelBuilder.ApplyConfiguration(new MonthlyUsageConfiguration());
+        modelBuilder.ApplyConfiguration(new UsageAdjustmentConfiguration());
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/CallParticipantConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/CallParticipantConfiguration.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class CallParticipantConfiguration : IEntityTypeConfiguration<CallParticipant>
+{
+    public void Configure(EntityTypeBuilder<CallParticipant> builder)
+    {
+        builder.ToTable("call_participants");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.BilledSeconds)
+            .IsRequired();
+
+        builder.Property(x => x.JoinedAt)
+            .HasColumnType("timestamp with time zone")
+            .IsRequired();
+
+        builder.Property(x => x.LeftAt)
+            .HasColumnType("timestamp with time zone");
+
+        builder.HasIndex(x => new { x.CallSessionId, x.UserId })
+            .IsUnique();
+
+        builder.HasOne(x => x.CallSession)
+            .WithMany(x => x.Participants)
+            .HasForeignKey(x => x.CallSessionId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.User)
+            .WithMany(x => x.CallParticipants)
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/CallSessionConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/CallSessionConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class CallSessionConfiguration : IEntityTypeConfiguration<CallSession>
+{
+    public void Configure(EntityTypeBuilder<CallSession> builder)
+    {
+        builder.ToTable("call_sessions");
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.CreatedByUserId).IsRequired();
+        builder.Property(x => x.Provider).HasMaxLength(40).IsRequired();
+        builder.Property(x => x.ProviderRoomId).HasMaxLength(200);
+        builder.Property(x => x.Status).HasConversion<string>().HasMaxLength(20).IsRequired();
+        builder.Property(x => x.CreatedAt).HasColumnType("timestamp with time zone").IsRequired();
+        builder.Property(x => x.StartedAt).HasColumnType("timestamp with time zone");
+        builder.Property(x => x.EndedAt).HasColumnType("timestamp with time zone");
+
+        builder.HasIndex(x => x.CreatedByUserId);
+        builder.HasIndex(x => x.Status);
+
+        builder
+            .HasOne(x => x.CreatedByUser)
+            .WithMany(u => u.CreatedCallSessions)
+            .HasForeignKey(x => x.CreatedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/ContactConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/ContactConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class ContactConfiguration : IEntityTypeConfiguration<Contact>
+{
+    public void Configure(EntityTypeBuilder<Contact> builder)
+    {
+        builder.ToTable("contacts");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.CreatedAt)
+            .HasColumnType("timestamp with time zone")
+            .IsRequired();
+
+        builder.HasOne(x => x.OwnerUser)
+            .WithMany(x => x.OwnedContacts)
+            .HasForeignKey(x => x.OwnerUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.ContactUser)
+            .WithMany(x => x.ContactOfUsers)
+            .HasForeignKey(x => x.ContactUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.OwnerUserId, x.ContactUserId })
+            .IsUnique();
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/MonthlyUsageConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/MonthlyUsageConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class MonthlyUsageConfiguration : IEntityTypeConfiguration<MonthlyUsage>
+{
+    public void Configure(EntityTypeBuilder<MonthlyUsage> builder)
+    {
+        builder.ToTable("monthly_usages");
+
+        builder.HasKey(x => new { x.UserId, x.MonthYYYYMM });
+
+        builder.Property(x => x.UsedSeconds)
+            .IsRequired();
+
+        builder.Property(x => x.UpdatedAt)
+            .HasColumnType("timestamp with time zone")
+            .IsRequired();
+
+        builder.HasOne(x => x.User)
+            .WithMany(x => x.MonthlyUsages)
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/UsageAdjustmentConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/UsageAdjustmentConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class UsageAdjustmentConfiguration : IEntityTypeConfiguration<UsageAdjustment>
+{
+    public void Configure(EntityTypeBuilder<UsageAdjustment> builder)
+    {
+        builder.ToTable("usage_adjustments");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Reason)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .HasColumnType("timestamp with time zone")
+            .IsRequired();
+
+        builder.HasIndex(x => new { x.UserId, x.MonthYYYYMM });
+
+        builder.HasOne(x => x.User)
+            .WithMany(u => u.UsageAdjustments)
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Minit.Api/Data/EntityConfigurations/UserConfiguration.cs
+++ b/Minit.Api/Data/EntityConfigurations/UserConfiguration.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Data.EntityConfigurations;
+
+public sealed class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.ToTable("users");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.DisplayName)
+            .HasMaxLength(80)
+            .IsRequired();
+
+        builder.Property(x => x.Code)
+            .HasMaxLength(8)
+            .IsFixedLength()
+            .IsRequired();
+
+        builder.HasIndex(x => x.Code)
+            .IsUnique();
+
+        builder.Property(x => x.MonthlyLimitSeconds)
+            .HasDefaultValue(6000)
+            .IsRequired();
+
+        builder.Property(x => x.IsActive)
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Property(x => x.CreatedAt)
+            .HasColumnType("timestamp with time zone")
+            .IsRequired();
+    }
+}

--- a/Minit.Api/Dockerfile
+++ b/Minit.Api/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY ["Minit.Api/Minit.Api.csproj", "Minit.Api/"]
+RUN dotnet restore "Minit.Api/Minit.Api.csproj"
+
+COPY . .
+RUN dotnet publish "Minit.Api/Minit.Api.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Minit.Api.dll"]

--- a/Minit.Api/Domain/CallParticipant.cs
+++ b/Minit.Api/Domain/CallParticipant.cs
@@ -1,0 +1,14 @@
+namespace Minit.Api.Domain;
+
+public sealed class CallParticipant
+{
+    public Guid Id { get; set; }
+    public Guid CallSessionId { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime JoinedAt { get; set; }
+    public DateTime? LeftAt { get; set; }
+    public int BilledSeconds { get; set; }
+
+    public CallSession? CallSession { get; set; }
+    public User? User { get; set; }
+}

--- a/Minit.Api/Domain/CallSession.cs
+++ b/Minit.Api/Domain/CallSession.cs
@@ -1,0 +1,16 @@
+namespace Minit.Api.Domain;
+
+public sealed class CallSession
+{
+    public Guid Id { get; set; }
+    public Guid CreatedByUserId { get; set; }
+    public string Provider { get; set; } = string.Empty;
+    public string? ProviderRoomId { get; set; }
+    public CallSessionStatus Status { get; set; } = CallSessionStatus.Created;
+    public DateTime CreatedAt { get; set; }
+    public DateTime? StartedAt { get; set; }
+    public DateTime? EndedAt { get; set; }
+
+    public User? CreatedByUser { get; set; }
+    public ICollection<CallParticipant> Participants { get; set; } = new List<CallParticipant>();
+}

--- a/Minit.Api/Domain/CallSessionStatus.cs
+++ b/Minit.Api/Domain/CallSessionStatus.cs
@@ -1,0 +1,9 @@
+namespace Minit.Api.Domain;
+
+public enum CallSessionStatus
+{
+    Created = 0,
+    Active = 1,
+    Ended = 2,
+    Cancelled = 3
+}

--- a/Minit.Api/Domain/Contact.cs
+++ b/Minit.Api/Domain/Contact.cs
@@ -1,0 +1,12 @@
+namespace Minit.Api.Domain;
+
+public sealed class Contact
+{
+    public Guid Id { get; set; }
+    public Guid OwnerUserId { get; set; }
+    public Guid ContactUserId { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public User? OwnerUser { get; set; }
+    public User? ContactUser { get; set; }
+}

--- a/Minit.Api/Domain/MonthlyUsage.cs
+++ b/Minit.Api/Domain/MonthlyUsage.cs
@@ -1,0 +1,11 @@
+namespace Minit.Api.Domain;
+
+public class MonthlyUsage
+{
+    public Guid UserId { get; set; }
+    public int MonthYYYYMM { get; set; }
+    public int UsedSeconds { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public User User { get; set; } = null!;
+}

--- a/Minit.Api/Domain/UsageAdjustment.cs
+++ b/Minit.Api/Domain/UsageAdjustment.cs
@@ -1,0 +1,13 @@
+namespace Minit.Api.Domain;
+
+public sealed class UsageAdjustment
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public int MonthYYYYMM { get; set; }
+    public int DeltaSeconds { get; set; }
+    public string Reason { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+
+    public User User { get; set; } = null!;
+}

--- a/Minit.Api/Domain/User.cs
+++ b/Minit.Api/Domain/User.cs
@@ -1,0 +1,18 @@
+namespace Minit.Api.Domain;
+
+public sealed class User
+{
+    public Guid Id { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public int MonthlyLimitSeconds { get; set; } = 6000;
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; }
+
+    public ICollection<Contact> OwnedContacts { get; set; } = new List<Contact>();
+    public ICollection<Contact> ContactOfUsers { get; set; } = new List<Contact>();
+    public ICollection<CallSession> CreatedCallSessions { get; set; } = new List<CallSession>();
+    public ICollection<CallParticipant> CallParticipants { get; set; } = new List<CallParticipant>();
+    public ICollection<MonthlyUsage> MonthlyUsages { get; set; } = new List<MonthlyUsage>();
+    public ICollection<UsageAdjustment> UsageAdjustments { get; set; } = new List<UsageAdjustment>();
+}

--- a/Minit.Api/Dtos/AdminDtos.cs
+++ b/Minit.Api/Dtos/AdminDtos.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Minit.Api.Dtos;
+
+public sealed record AdminSetUserLimitRequestDto(
+    [property: Range(1, int.MaxValue)] int? Minutes,
+    [property: Range(1, int.MaxValue)] int? Seconds);
+
+public sealed record UserLimitResponseDto(
+    Guid UserId,
+    int MonthlyLimitSeconds,
+    int MonthlyLimitMinutes);
+
+public sealed record CreateUsageAdjustmentRequestDto(
+    [property: Required] Guid UserId,
+    [property: Range(190001, 999912)] int MonthYYYYMM,
+    int DeltaSeconds,
+    [property: Required, StringLength(200, MinimumLength = 1)] string Reason);
+
+public sealed record UsageAdjustmentResponseDto(
+    Guid Id,
+    Guid UserId,
+    int MonthYYYYMM,
+    int DeltaSeconds,
+    string Reason,
+    DateTime CreatedAtUtc,
+    int NewUsedSeconds);

--- a/Minit.Api/Dtos/CallDtos.cs
+++ b/Minit.Api/Dtos/CallDtos.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Minit.Api.Dtos;
+
+public sealed record StartCallRequest(
+    [property: Required] Guid CreatedByUserId,
+    [property: Required] Guid CalleeUserId,
+    [property: MaxLength(40)] string? Provider,
+    [property: MaxLength(200)] string? ProviderRoomId);
+
+public sealed record StartCallResponse(
+    Guid CallId,
+    Guid CreatedByUserId,
+    Guid CalleeUserId,
+    string Provider,
+    string? ProviderRoomId,
+    string Status,
+    DateTime? StartedAtUtc,
+    int RemainingSecondsBeforeStart);
+
+public sealed record JoinCallRequest([property: Required] Guid UserId);
+
+public sealed record JoinCallResponse(
+    Guid ParticipantId,
+    Guid CallSessionId,
+    Guid UserId,
+    DateTime JoinedAtUtc);
+
+public sealed record EndCallRequest([property: Required] Guid EndedByUserId);
+
+public sealed record EndCallResponse(
+    Guid CallId,
+    string Status,
+    DateTime? EndedAtUtc,
+    int BilledSecondsCreator,
+    Guid? BilledUserId);

--- a/Minit.Api/Dtos/ContactDtos.cs
+++ b/Minit.Api/Dtos/ContactDtos.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Minit.Api.Dtos;
+
+public sealed record AddContactRequest(
+    [property: Required] Guid OwnerUserId,
+    [property: Required, StringLength(8, MinimumLength = 8)] string ContactCode);
+
+public sealed record AddContactResponse(
+    Guid ContactId,
+    Guid OwnerUserId,
+    Guid ContactUserId,
+    string DisplayName,
+    DateTime CreatedAtUtc);
+
+public sealed record ContactItemResponse(
+    Guid ContactUserId,
+    string DisplayName,
+    string Code,
+    DateTime AddedAtUtc);

--- a/Minit.Api/Dtos/UsageDtos.cs
+++ b/Minit.Api/Dtos/UsageDtos.cs
@@ -1,0 +1,9 @@
+namespace Minit.Api.Dtos;
+
+public sealed record MonthlyUsageResponse(
+    Guid UserId,
+    int MonthYYYYMM,
+    int MonthlyLimitSeconds,
+    int UsedSeconds,
+    int RemainingSeconds,
+    DateTime UpdatedAtUtc);

--- a/Minit.Api/Dtos/UserDtos.cs
+++ b/Minit.Api/Dtos/UserDtos.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Minit.Api.Dtos;
+
+public sealed record RegisterUserRequest(
+    [property: Required, StringLength(80, MinimumLength = 1)] string DisplayName);
+
+public sealed record RegisterUserResponse(Guid UserId, string DisplayName, string Code, int MonthlyLimitSeconds, DateTime CreatedAtUtc);
+
+public sealed record UserByCodeResponse(Guid UserId, string DisplayName);

--- a/Minit.Api/Endpoints/AdminEndpoints.cs
+++ b/Minit.Api/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,148 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Domain;
+using Minit.Api.Dtos;
+using Minit.Api.Security;
+using Minit.Api.Services;
+
+namespace Minit.Api.Endpoints;
+
+public static class AdminEndpoints
+{
+    public static RouteGroupBuilder MapAdminEndpoints(this RouteGroupBuilder api)
+    {
+        var group = api.MapGroup("/admin")
+            .WithTags("Admin")
+            .AddEndpointFilter<AdminApiKeyEndpointFilter>();
+
+        group.MapPatch("/users/{userId:guid}/limit", SetUserLimitAsync)
+            .WithName("SetUserLimit")
+            .WithSummary("Set user monthly limit in seconds or minutes.")
+            .Produces<UserLimitResponseDto>(StatusCodes.Status200OK)
+            .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/usage-adjustments", CreateUsageAdjustmentAsync)
+            .WithName("CreateUsageAdjustment")
+            .WithSummary("Create a monthly usage adjustment and apply it.")
+            .Produces<UsageAdjustmentResponseDto>(StatusCodes.Status201Created)
+            .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<IResult> SetUserLimitAsync(
+        [FromRoute] Guid userId,
+        [FromBody] AdminSetUserLimitRequestDto request,
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        if (request.Minutes is null && request.Seconds is null)
+        {
+            return Results.Problem(
+                title: "Validation failed",
+                detail: "Provide either minutes or seconds.",
+                statusCode: StatusCodes.Status400BadRequest,
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "validation_error" });
+        }
+
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return Results.Problem(
+                title: "User not found",
+                detail: "User does not exist.",
+                statusCode: StatusCodes.Status404NotFound,
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" });
+        }
+
+        var newSeconds = request.Seconds ?? request.Minutes!.Value * 60;
+        if (newSeconds <= 0)
+        {
+            return Results.Problem(
+                title: "Validation failed",
+                detail: "Monthly limit must be greater than zero.",
+                statusCode: StatusCodes.Status400BadRequest,
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "validation_error" });
+        }
+
+        user.MonthlyLimitSeconds = newSeconds;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.Ok(new UserLimitResponseDto(
+            user.Id,
+            user.MonthlyLimitSeconds,
+            user.MonthlyLimitSeconds / 60));
+    }
+
+    private static async Task<IResult> CreateUsageAdjustmentAsync(
+        [FromBody] CreateUsageAdjustmentRequestDto request,
+        AppDbContext dbContext,
+        IQuotaService quotaService,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValidMonth(request.MonthYYYYMM))
+        {
+            return Results.Problem(
+                title: "Invalid month",
+                detail: "MonthYYYYMM is invalid.",
+                statusCode: StatusCodes.Status400BadRequest,
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "invalid_month" });
+        }
+
+        var user = await dbContext.Users.FirstOrDefaultAsync(u => u.Id == request.UserId, cancellationToken);
+        if (user is null)
+        {
+            return Results.Problem(
+                title: "User not found",
+                detail: "User does not exist.",
+                statusCode: StatusCodes.Status404NotFound,
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" });
+        }
+
+        await using var tx = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+        var usage = await quotaService.GetOrCreateMonthlyUsageAsync(request.UserId, request.MonthYYYYMM, cancellationToken);
+        usage.UsedSeconds = Math.Max(0, usage.UsedSeconds + request.DeltaSeconds);
+        usage.UpdatedAt = DateTimeProvider.UtcNow;
+
+        var adjustment = new UsageAdjustment
+        {
+            Id = Guid.NewGuid(),
+            UserId = request.UserId,
+            MonthYYYYMM = request.MonthYYYYMM,
+            DeltaSeconds = request.DeltaSeconds,
+            Reason = request.Reason.Trim(),
+            CreatedAt = DateTimeProvider.UtcNow
+        };
+
+        dbContext.UsageAdjustments.Add(adjustment);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
+
+        return Results.Created(
+            $"/api/admin/usage-adjustments/{adjustment.Id}",
+            new UsageAdjustmentResponseDto(
+                adjustment.Id,
+                adjustment.UserId,
+                adjustment.MonthYYYYMM,
+                adjustment.DeltaSeconds,
+                adjustment.Reason,
+                adjustment.CreatedAt,
+                usage.UsedSeconds));
+    }
+
+    private static bool IsValidMonth(int yyyymm)
+    {
+        if (yyyymm < 190001 || yyyymm > 999912)
+        {
+            return false;
+        }
+
+        var month = yyyymm % 100;
+        return month is >= 1 and <= 12;
+    }
+}

--- a/Minit.Api/Endpoints/CallsEndpoints.cs
+++ b/Minit.Api/Endpoints/CallsEndpoints.cs
@@ -1,0 +1,259 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Domain;
+using Minit.Api.Dtos;
+using Minit.Api.Services;
+
+namespace Minit.Api.Endpoints;
+
+public static class CallsEndpoints
+{
+    public static RouteGroupBuilder MapCallsEndpoints(this RouteGroupBuilder api)
+    {
+        var group = api.MapGroup("/calls").WithTags("Calls");
+
+        group.MapPost("/start", StartCallAsync)
+            .WithName("StartCall")
+            .WithSummary("Start a call session")
+            .Produces<StartCallResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/{callId:guid}/join", JoinCallAsync)
+            .WithName("JoinCall")
+            .WithSummary("Join an active call session")
+            .Produces<JoinCallResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        group.MapPost("/{callId:guid}/end", EndCallAsync)
+            .WithName("EndCall")
+            .WithSummary("End a call session and bill creator usage")
+            .Produces<EndCallResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<Results<Created<StartCallResponse>, ProblemHttpResult>> StartCallAsync(
+        StartCallRequest request,
+        AppDbContext dbContext,
+        IQuotaService quotaService,
+        CancellationToken cancellationToken)
+    {
+        if (request.CreatedByUserId == request.CalleeUserId)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid request",
+                detail: "Caller and callee cannot be the same user.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "invalid_participants" });
+        }
+
+        var creator = await dbContext.Users
+            .FirstOrDefaultAsync(x => x.Id == request.CreatedByUserId && x.IsActive, cancellationToken);
+        if (creator is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Creator not found",
+                detail: "The caller user does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "creator_not_found" });
+        }
+
+        var callee = await dbContext.Users
+            .FirstOrDefaultAsync(x => x.Id == request.CalleeUserId && x.IsActive, cancellationToken);
+        if (callee is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Callee not found",
+                detail: "The callee user does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "callee_not_found" });
+        }
+
+        var now = DateTimeProvider.UtcNow;
+        var remaining = await quotaService.CheckRemainingSecondsAsync(creator.Id, now, cancellationToken);
+        if (remaining <= 0)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status403Forbidden,
+                title: "Quota exceeded",
+                detail: "No remaining monthly call seconds.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "quota_exceeded" });
+        }
+
+        var session = new CallSession
+        {
+            Id = Guid.NewGuid(),
+            CreatedByUserId = creator.Id,
+            Provider = string.IsNullOrWhiteSpace(request.Provider) ? "internal" : request.Provider.Trim(),
+            ProviderRoomId = string.IsNullOrWhiteSpace(request.ProviderRoomId) ? null : request.ProviderRoomId.Trim(),
+            Status = CallSessionStatus.Active,
+            CreatedAt = now,
+            StartedAt = now
+        };
+
+        var creatorParticipant = new CallParticipant
+        {
+            Id = Guid.NewGuid(),
+            CallSessionId = session.Id,
+            UserId = creator.Id,
+            JoinedAt = now
+        };
+
+        dbContext.CallSessions.Add(session);
+        dbContext.CallParticipants.Add(creatorParticipant);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return TypedResults.Created($"/api/calls/{session.Id}", new StartCallResponse(
+            session.Id,
+            creator.Id,
+            callee.Id,
+            session.Provider,
+            session.ProviderRoomId,
+            session.Status.ToString(),
+            session.StartedAt,
+            remaining));
+    }
+
+    private static async Task<Results<Ok<JoinCallResponse>, ProblemHttpResult>> JoinCallAsync(
+        Guid callId,
+        JoinCallRequest request,
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var session = await dbContext.CallSessions
+            .FirstOrDefaultAsync(x => x.Id == callId, cancellationToken);
+        if (session is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Call not found",
+                detail: "Call session was not found.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "call_not_found" });
+        }
+
+        if (session.Status is CallSessionStatus.Ended or CallSessionStatus.Cancelled)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid call state",
+                detail: "Cannot join an ended or cancelled call.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "invalid_call_state" });
+        }
+
+        var user = await dbContext.Users
+            .FirstOrDefaultAsync(x => x.Id == request.UserId && x.IsActive, cancellationToken);
+        if (user is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "User not found",
+                detail: "User does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" });
+        }
+
+        var participant = await dbContext.CallParticipants
+            .FirstOrDefaultAsync(x => x.CallSessionId == callId && x.UserId == request.UserId, cancellationToken);
+
+        if (participant is null)
+        {
+            participant = new CallParticipant
+            {
+                Id = Guid.NewGuid(),
+                CallSessionId = callId,
+                UserId = request.UserId,
+                JoinedAt = DateTimeProvider.UtcNow
+            };
+            dbContext.CallParticipants.Add(participant);
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return TypedResults.Ok(new JoinCallResponse(
+            participant.Id,
+            participant.CallSessionId,
+            participant.UserId,
+            participant.JoinedAt));
+    }
+
+    private static async Task<Results<Ok<EndCallResponse>, ProblemHttpResult>> EndCallAsync(
+        Guid callId,
+        EndCallRequest request,
+        AppDbContext dbContext,
+        IQuotaService quotaService,
+        CancellationToken cancellationToken)
+    {
+        var session = await dbContext.CallSessions
+            .FirstOrDefaultAsync(x => x.Id == callId, cancellationToken);
+        if (session is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Call not found",
+                detail: "Call session was not found.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "call_not_found" });
+        }
+
+        var endedBy = await dbContext.Users
+            .FirstOrDefaultAsync(x => x.Id == request.EndedByUserId && x.IsActive, cancellationToken);
+        if (endedBy is null)
+        {
+            return TypedResults.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "User not found",
+                detail: "EndedBy user does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" });
+        }
+
+        if (session.Status == CallSessionStatus.Ended)
+        {
+            return TypedResults.Ok(new EndCallResponse(
+                session.Id,
+                session.Status.ToString(),
+                session.EndedAt,
+                0,
+                session.CreatedByUserId));
+        }
+
+        var now = DateTimeProvider.UtcNow;
+        var startedAt = session.StartedAt ?? session.CreatedAt;
+        var durationSeconds = Math.Max(0, (int)Math.Ceiling((now - startedAt).TotalSeconds));
+
+        await using var tx = await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        session.Status = CallSessionStatus.Ended;
+        session.EndedAt = now;
+
+        var creatorParticipant = await dbContext.CallParticipants
+            .FirstOrDefaultAsync(x => x.CallSessionId == callId && x.UserId == session.CreatedByUserId, cancellationToken);
+        if (creatorParticipant is null)
+        {
+            creatorParticipant = new CallParticipant
+            {
+                Id = Guid.NewGuid(),
+                CallSessionId = callId,
+                UserId = session.CreatedByUserId,
+                JoinedAt = startedAt
+            };
+            dbContext.CallParticipants.Add(creatorParticipant);
+        }
+
+        creatorParticipant.LeftAt ??= now;
+        creatorParticipant.BilledSeconds = durationSeconds;
+
+        await quotaService.ApplyBillingAsync(session.CreatedByUserId, durationSeconds, now, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await tx.CommitAsync(cancellationToken);
+
+        return TypedResults.Ok(new EndCallResponse(
+            session.Id,
+            session.Status.ToString(),
+            session.EndedAt,
+            durationSeconds,
+            session.CreatedByUserId));
+    }
+}

--- a/Minit.Api/Endpoints/ContactsEndpoints.cs
+++ b/Minit.Api/Endpoints/ContactsEndpoints.cs
@@ -1,0 +1,129 @@
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Domain;
+using Minit.Api.Dtos;
+using Minit.Api.Services;
+
+namespace Minit.Api.Endpoints;
+
+public static class ContactsEndpoints
+{
+    public static RouteGroupBuilder MapContactsEndpoints(this RouteGroupBuilder api)
+    {
+        var group = api.MapGroup("/contacts")
+            .WithTags("Contacts");
+
+        group.MapPost("/add", AddContactAsync)
+            .WithName("AddContact")
+            .WithSummary("Add contact by code")
+            .Produces<AddContactResponse>(StatusCodes.Status201Created)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict);
+
+        group.MapGet("/{ownerUserId:guid}", GetContactsAsync)
+            .WithName("GetContacts")
+            .WithSummary("List contacts for an owner")
+            .Produces<List<ContactItemResponse>>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<IResult> AddContactAsync(
+        AddContactRequest request,
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var owner = await dbContext.Users
+            .SingleOrDefaultAsync(x => x.Id == request.OwnerUserId && x.IsActive, cancellationToken);
+        if (owner is null)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Owner not found",
+                detail: "Owner user does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "owner_not_found" });
+        }
+
+        var normalizedCode = request.ContactCode.Trim().ToUpperInvariant();
+        var contactUser = await dbContext.Users
+            .SingleOrDefaultAsync(x => x.Code == normalizedCode && x.IsActive, cancellationToken);
+        if (contactUser is null)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Contact not found",
+                detail: "No user found for the provided code.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "contact_not_found" });
+        }
+
+        if (contactUser.Id == owner.Id)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid contact",
+                detail: "Users cannot add themselves as contact.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "cannot_add_self" });
+        }
+
+        var alreadyExists = await dbContext.Contacts
+            .AnyAsync(x => x.OwnerUserId == owner.Id && x.ContactUserId == contactUser.Id, cancellationToken);
+        if (alreadyExists)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status409Conflict,
+                title: "Contact already exists",
+                detail: "This contact is already in the owner's contact list.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "contact_exists" });
+        }
+
+        var contact = new Contact
+        {
+            Id = Guid.NewGuid(),
+            OwnerUserId = owner.Id,
+            ContactUserId = contactUser.Id,
+            CreatedAt = DateTimeProvider.UtcNow
+        };
+
+        dbContext.Contacts.Add(contact);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Results.Created($"/api/contacts/{owner.Id}", new AddContactResponse(
+            contact.Id,
+            owner.Id,
+            contactUser.Id,
+            contactUser.DisplayName,
+            contact.CreatedAt));
+    }
+
+    private static async Task<IResult> GetContactsAsync(
+        Guid ownerUserId,
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        var ownerExists = await dbContext.Users
+            .AnyAsync(x => x.Id == ownerUserId && x.IsActive, cancellationToken);
+        if (!ownerExists)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Owner not found",
+                detail: "Owner user does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "owner_not_found" });
+        }
+
+        var contacts = await dbContext.Contacts
+            .AsNoTracking()
+            .Where(x => x.OwnerUserId == ownerUserId)
+            .OrderByDescending(x => x.CreatedAt)
+            .Select(x => new ContactItemResponse(
+                x.ContactUserId,
+                x.ContactUser!.DisplayName,
+                x.ContactUser.Code,
+                x.CreatedAt))
+            .ToListAsync(cancellationToken);
+
+        return Results.Ok(contacts);
+    }
+}

--- a/Minit.Api/Endpoints/UsageEndpoints.cs
+++ b/Minit.Api/Endpoints/UsageEndpoints.cs
@@ -1,0 +1,74 @@
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Dtos;
+using Minit.Api.Services;
+
+namespace Minit.Api.Endpoints;
+
+public static class UsageEndpoints
+{
+    public static RouteGroupBuilder MapUsageEndpoints(this RouteGroupBuilder api)
+    {
+        var group = api.MapGroup("/usage").WithTags("Usage");
+
+        group.MapGet("/{userId:guid}/month/{yyyymm:int}", GetUsageByMonthAsync)
+            .WithName("GetUsageByMonth")
+            .WithSummary("Get monthly usage for a user")
+            .Produces<MonthlyUsageResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound);
+
+        return group;
+    }
+
+    private static async Task<IResult> GetUsageByMonthAsync(
+        Guid userId,
+        int yyyymm,
+        AppDbContext dbContext,
+        IQuotaService quotaService,
+        CancellationToken cancellationToken)
+    {
+        if (!IsValidMonth(yyyymm))
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid month",
+                detail: "MonthYYYYMM is invalid.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "invalid_month" });
+        }
+
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .SingleOrDefaultAsync(u => u.Id == userId && u.IsActive, cancellationToken);
+        if (user is null)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "User not found",
+                detail: "User does not exist or is inactive.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" });
+        }
+
+        var usage = await quotaService.GetOrCreateMonthlyUsageAsync(userId, yyyymm, cancellationToken);
+        var remaining = Math.Max(0, user.MonthlyLimitSeconds - usage.UsedSeconds);
+
+        return Results.Ok(new MonthlyUsageResponse(
+            user.Id,
+            yyyymm,
+            user.MonthlyLimitSeconds,
+            usage.UsedSeconds,
+            remaining,
+            usage.UpdatedAt));
+    }
+
+    private static bool IsValidMonth(int yyyymm)
+    {
+        if (yyyymm < 190001 || yyyymm > 999912)
+        {
+            return false;
+        }
+
+        var month = yyyymm % 100;
+        return month is >= 1 and <= 12;
+    }
+}

--- a/Minit.Api/Endpoints/UsersEndpoints.cs
+++ b/Minit.Api/Endpoints/UsersEndpoints.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Domain;
+using Minit.Api.Dtos;
+using Minit.Api.Services;
+
+namespace Minit.Api.Endpoints;
+
+public static class UsersEndpoints
+{
+    public static RouteGroupBuilder MapUsersEndpoints(this RouteGroupBuilder api)
+    {
+        var group = api.MapGroup("/users").WithTags("Users");
+
+        group.MapPost("/register", RegisterUserAsync)
+            .WithName("RegisterUser")
+            .WithSummary("Register user and generate unique code")
+            .RequireRateLimiting("public-per-ip")
+            .Produces<RegisterUserResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status409Conflict)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        group.MapGet("/by-code/{code}", GetByCodeAsync)
+            .WithName("GetUserByCode")
+            .WithSummary("Find user by 8-char code")
+            .RequireRateLimiting("public-per-ip")
+            .Produces<UserByCodeResponse>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests);
+
+        return group;
+    }
+
+    private static async Task<IResult> RegisterUserAsync(
+        [FromBody] RegisterUserRequest request,
+        AppDbContext dbContext,
+        IUserCodeGenerator userCodeGenerator,
+        CancellationToken cancellationToken)
+    {
+        var displayName = request.DisplayName.Trim();
+        var now = DateTimeProvider.UtcNow;
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = displayName,
+            MonthlyLimitSeconds = 6000,
+            IsActive = true,
+            CreatedAt = now
+        };
+
+        const int maxRetries = 8;
+        for (var i = 0; i < maxRetries; i++)
+        {
+            user.Code = userCodeGenerator.Generate();
+            dbContext.Users.Add(user);
+
+            try
+            {
+                await dbContext.SaveChangesAsync(cancellationToken);
+                return Results.Created(
+                    $"/api/users/{user.Id}",
+                    new RegisterUserResponse(user.Id, user.DisplayName, user.Code, user.MonthlyLimitSeconds, user.CreatedAt));
+            }
+            catch (DbUpdateException) when (i < maxRetries - 1)
+            {
+                dbContext.Entry(user).State = EntityState.Detached;
+            }
+        }
+
+        return Results.Problem(
+            statusCode: StatusCodes.Status409Conflict,
+            title: "Could not allocate unique user code",
+            detail: "Failed to generate a unique user code after multiple attempts.",
+            extensions: new Dictionary<string, object?> { ["errorCode"] = "code_generation_conflict" });
+    }
+
+    private static async Task<IResult> GetByCodeAsync(
+        string code,
+        AppDbContext dbContext,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(code) || code.Length != 8)
+        {
+            return Results.Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Invalid code",
+                detail: "Code must be exactly 8 characters.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "invalid_code" });
+        }
+
+        var normalizedCode = code.Trim().ToUpperInvariant();
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .Where(x => x.IsActive && x.Code == normalizedCode)
+            .Select(x => new UserByCodeResponse(x.Id, x.DisplayName))
+            .SingleOrDefaultAsync(cancellationToken);
+
+        return user is null
+            ? Results.Problem(
+                statusCode: StatusCodes.Status404NotFound,
+                title: "User not found",
+                detail: "No active user found for the provided code.",
+                extensions: new Dictionary<string, object?> { ["errorCode"] = "user_not_found" })
+            : Results.Ok(user);
+    }
+}

--- a/Minit.Api/Minit.Api.csproj
+++ b/Minit.Api/Minit.Api.csproj
@@ -4,14 +4,18 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>14.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Minit.Api/Program.cs
+++ b/Minit.Api/Program.cs
@@ -1,23 +1,126 @@
+using System.Threading.RateLimiting;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using Minit.Api.Data;
+using Minit.Api.Endpoints;
+using Minit.Api.Security;
+using Minit.Api.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
+builder.Logging.ClearProviders();
+builder.Logging.AddJsonConsole();
 
-builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.PropertyNamingPolicy = null;
+});
+
+builder.Services.Configure<RouteHandlerOptions>(options =>
+{
+    options.ThrowOnBadRequest = true;
+});
+
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = context =>
+    {
+        context.ProblemDetails.Extensions["traceId"] = context.HttpContext.TraceIdentifier;
+    };
+});
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "WhatsApp-Like Backend API",
+        Version = "v1",
+        Description = "Backend API for user registration, contacts, calling, and quota management."
+    });
+    options.AddSecurityDefinition("AdminApiKey", new OpenApiSecurityScheme
+    {
+        Name = AdminApiKeyConstants.HeaderName,
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Description = "Admin API key header for /api/admin endpoints."
+    });
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "AdminApiKey"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
+builder.Services.Configure<AdminOptions>(builder.Configuration.GetSection(AdminOptions.SectionName));
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddScoped<IQuotaService, QuotaService>();
+builder.Services.AddScoped<IUserCodeGenerator, UserCodeGenerator>();
+builder.Services.AddScoped<AdminApiKeyEndpointFilter>();
+builder.Services.AddScoped<ValidationEndpointFilter>();
+
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.AddPolicy("public-per-ip", httpContext =>
+    {
+        var key = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            key,
+            _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 30,
+                Window = TimeSpan.FromMinutes(1),
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                AutoReplenishment = true
+            });
+    });
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        var problem = new
+        {
+            type = "https://httpstatuses.com/429",
+            title = "Too Many Requests",
+            status = StatusCodes.Status429TooManyRequests,
+            detail = "Rate limit exceeded. Try again later.",
+            errorCode = "rate_limited",
+            traceId = context.HttpContext.TraceIdentifier
+        };
+        context.HttpContext.Response.ContentType = "application/problem+json";
+        await context.HttpContext.Response.WriteAsJsonAsync(problem, cancellationToken);
+    };
+});
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
+app.UseMiddleware<GlobalExceptionMiddleware>();
+app.UseRateLimiter();
 
-app.UseHttpsRedirection();
+app.UseSwagger();
+app.UseSwaggerUI();
 
-app.UseAuthorization();
+var api = app.MapGroup("/api")
+    .AddEndpointFilter<ValidationEndpointFilter>();
 
-app.MapControllers();
+api.MapUsersEndpoints();
+api.MapContactsEndpoints();
+api.MapCallsEndpoints();
+api.MapUsageEndpoints();
+api.MapAdminEndpoints();
 
 app.Run();
+
+public partial class Program;

--- a/Minit.Api/Security/AdminApiKeyConstants.cs
+++ b/Minit.Api/Security/AdminApiKeyConstants.cs
@@ -1,0 +1,6 @@
+namespace Minit.Api.Security;
+
+public static class AdminApiKeyConstants
+{
+    public const string HeaderName = "X-Admin-Key";
+}

--- a/Minit.Api/Security/AdminApiKeyEndpointFilter.cs
+++ b/Minit.Api/Security/AdminApiKeyEndpointFilter.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Minit.Api.Security;
+
+public sealed class AdminApiKeyEndpointFilter(IOptions<AdminOptions> adminOptions) : IEndpointFilter
+{
+    public ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(AdminApiKeyConstants.HeaderName, out var apiKeyHeader))
+        {
+            return ValueTask.FromResult<object?>(
+                Results.Problem(
+                    title: "Unauthorized",
+                    detail: "Missing admin API key.",
+                    statusCode: StatusCodes.Status401Unauthorized,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "admin_key_missing" }));
+        }
+
+        var expectedKey = adminOptions.Value.ApiKey;
+        var providedKey = apiKeyHeader.ToString();
+        if (string.IsNullOrWhiteSpace(expectedKey))
+        {
+            return ValueTask.FromResult<object?>(
+                Results.Problem(
+                    title: "Unauthorized",
+                    detail: "Admin API key is not configured.",
+                    statusCode: StatusCodes.Status401Unauthorized,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "admin_key_not_configured" }));
+        }
+
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedKey);
+        var providedBytes = Encoding.UTF8.GetBytes(providedKey);
+        if (expectedBytes.Length != providedBytes.Length || !CryptographicOperations.FixedTimeEquals(expectedBytes, providedBytes))
+        {
+            return ValueTask.FromResult<object?>(
+                Results.Problem(
+                    title: "Unauthorized",
+                    detail: "Invalid admin API key.",
+                    statusCode: StatusCodes.Status401Unauthorized,
+                    extensions: new Dictionary<string, object?> { ["errorCode"] = "admin_key_invalid" }));
+        }
+
+        return next(context);
+    }
+}

--- a/Minit.Api/Security/AdminOptions.cs
+++ b/Minit.Api/Security/AdminOptions.cs
@@ -1,0 +1,8 @@
+namespace Minit.Api.Security;
+
+public sealed class AdminOptions
+{
+    public const string SectionName = "Admin";
+
+    public string ApiKey { get; init; } = string.Empty;
+}

--- a/Minit.Api/Services/DateTimeProvider.cs
+++ b/Minit.Api/Services/DateTimeProvider.cs
@@ -1,0 +1,12 @@
+namespace Minit.Api.Services;
+
+public static class DateTimeProvider
+{
+    public static DateTime UtcNow => DateTime.UtcNow;
+
+    public static int ToMonthYYYYMM(DateTime utcDate)
+    {
+        var normalized = utcDate.Kind == DateTimeKind.Utc ? utcDate : utcDate.ToUniversalTime();
+        return (normalized.Year * 100) + normalized.Month;
+    }
+}

--- a/Minit.Api/Services/GlobalExceptionMiddleware.cs
+++ b/Minit.Api/Services/GlobalExceptionMiddleware.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Minit.Api.Services;
+
+public sealed class GlobalExceptionMiddleware(RequestDelegate next, ILogger<GlobalExceptionMiddleware> logger)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception at {Path}", context.Request.Path);
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            context.Response.ContentType = "application/problem+json";
+
+            var problem = new ProblemDetails
+            {
+                Type = "https://httpstatuses.com/500",
+                Title = "Unexpected Server Error",
+                Status = StatusCodes.Status500InternalServerError,
+                Detail = "An unexpected error occurred. Please retry later."
+            };
+            problem.Extensions["errorCode"] = "internal_error";
+            problem.Extensions["traceId"] = context.TraceIdentifier;
+
+            await context.Response.WriteAsJsonAsync(problem);
+        }
+    }
+}

--- a/Minit.Api/Services/IQuotaService.cs
+++ b/Minit.Api/Services/IQuotaService.cs
@@ -1,0 +1,10 @@
+using Minit.Api.Domain;
+
+namespace Minit.Api.Services;
+
+public interface IQuotaService
+{
+    Task<MonthlyUsage> GetOrCreateMonthlyUsageAsync(Guid userId, int monthYyyyMm, CancellationToken cancellationToken = default);
+    Task<int> CheckRemainingSecondsAsync(Guid userId, DateTime utcNow, CancellationToken cancellationToken = default);
+    Task ApplyBillingAsync(Guid userId, int billedSeconds, DateTime utcNow, CancellationToken cancellationToken = default);
+}

--- a/Minit.Api/Services/IUserCodeGenerator.cs
+++ b/Minit.Api/Services/IUserCodeGenerator.cs
@@ -1,0 +1,6 @@
+namespace Minit.Api.Services;
+
+public interface IUserCodeGenerator
+{
+    string Generate();
+}

--- a/Minit.Api/Services/QuotaService.cs
+++ b/Minit.Api/Services/QuotaService.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore;
+using Minit.Api.Data;
+using Minit.Api.Domain;
+
+namespace Minit.Api.Services;
+
+public sealed class QuotaService(AppDbContext dbContext) : IQuotaService
+{
+    public async Task<MonthlyUsage> GetOrCreateMonthlyUsageAsync(
+        Guid userId,
+        int monthYYYYMM,
+        CancellationToken cancellationToken = default)
+    {
+        var usage = await dbContext.MonthlyUsages
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.MonthYYYYMM == monthYYYYMM, cancellationToken);
+        if (usage is not null)
+        {
+            return usage;
+        }
+
+        usage = new MonthlyUsage
+        {
+            UserId = userId,
+            MonthYYYYMM = monthYYYYMM,
+            UsedSeconds = 0,
+            UpdatedAt = DateTimeProvider.UtcNow
+        };
+        dbContext.MonthlyUsages.Add(usage);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return usage;
+    }
+
+    public async Task<int> CheckRemainingSecondsAsync(
+        Guid userId,
+        DateTime utcNow,
+        CancellationToken cancellationToken = default)
+    {
+        var monthYYYYMM = DateTimeProvider.ToMonthYYYYMM(utcNow);
+        var user = await dbContext.Users
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.Id == userId && x.IsActive, cancellationToken);
+        if (user is null)
+        {
+            return 0;
+        }
+
+        var usage = await dbContext.MonthlyUsages
+            .AsNoTracking()
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.MonthYYYYMM == monthYYYYMM, cancellationToken);
+
+        var used = usage?.UsedSeconds ?? 0;
+        var remaining = user.MonthlyLimitSeconds - used;
+        return Math.Max(remaining, 0);
+    }
+
+    public async Task ApplyBillingAsync(
+        Guid userId,
+        int billedSeconds,
+        DateTime utcNow,
+        CancellationToken cancellationToken = default)
+    {
+        if (billedSeconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(billedSeconds), "Billed seconds cannot be negative.");
+        }
+
+        var monthYYYYMM = DateTimeProvider.ToMonthYYYYMM(utcNow);
+        var usage = await dbContext.MonthlyUsages
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.MonthYYYYMM == monthYYYYMM, cancellationToken);
+
+        if (usage is null)
+        {
+            usage = new MonthlyUsage
+            {
+                UserId = userId,
+                MonthYYYYMM = monthYYYYMM,
+                UsedSeconds = billedSeconds,
+                UpdatedAt = DateTimeProvider.UtcNow
+            };
+            dbContext.MonthlyUsages.Add(usage);
+            return;
+        }
+
+        usage.UsedSeconds += billedSeconds;
+        usage.UpdatedAt = DateTimeProvider.UtcNow;
+    }
+}

--- a/Minit.Api/Services/UserCodeGenerator.cs
+++ b/Minit.Api/Services/UserCodeGenerator.cs
@@ -1,0 +1,27 @@
+using System.Security.Cryptography;
+
+namespace Minit.Api.Services;
+
+public sealed class UserCodeGenerator : IUserCodeGenerator
+{
+    private const string Alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private const int CodeLength = 8;
+    public string Generate()
+    {
+        return GenerateCode();
+    }
+
+    private static string GenerateCode()
+    {
+        Span<char> chars = stackalloc char[CodeLength];
+        Span<byte> randomBytes = stackalloc byte[CodeLength];
+        RandomNumberGenerator.Fill(randomBytes);
+
+        for (var i = 0; i < CodeLength; i++)
+        {
+            chars[i] = Alphabet[randomBytes[i] % Alphabet.Length];
+        }
+
+        return new string(chars);
+    }
+}

--- a/Minit.Api/Services/ValidationEndpointFilter.cs
+++ b/Minit.Api/Services/ValidationEndpointFilter.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Minit.Api.Services;
+
+public sealed class ValidationEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var validationFailures = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var argument in context.Arguments.Where(x => x is not null))
+        {
+            var validationContext = new ValidationContext(argument!);
+            var validationResults = new List<ValidationResult>();
+
+            if (Validator.TryValidateObject(argument!, validationContext, validationResults, validateAllProperties: true))
+            {
+                continue;
+            }
+
+            foreach (var validationResult in validationResults)
+            {
+                var memberName = validationResult.MemberNames.FirstOrDefault() ?? string.Empty;
+                if (!validationFailures.TryGetValue(memberName, out var errors))
+                {
+                    validationFailures[memberName] = [validationResult.ErrorMessage ?? "Validation failed."];
+                }
+                else
+                {
+                    validationFailures[memberName] = [.. errors, validationResult.ErrorMessage ?? "Validation failed."];
+                }
+            }
+        }
+
+        if (validationFailures.Count > 0)
+        {
+            return Results.ValidationProblem(validationFailures);
+        }
+
+        return await next(context);
+    }
+}

--- a/Minit.Api/appsettings.Development.json
+++ b/Minit.Api/appsettings.Development.json
@@ -1,8 +1,14 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=minitdb;Username=minit;Password=minit_password"
+  },
+  "Admin": {
+    "ApiKey": "dev-super-secret-admin-key"
   }
 }

--- a/Minit.Api/appsettings.json
+++ b/Minit.Api/appsettings.json
@@ -1,4 +1,10 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=minit_api;Username=postgres;Password=postgres"
+  },
+  "Admin": {
+    "ApiKey": "change-me-admin-key"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Readme
+++ b/Readme
@@ -1,1 +1,404 @@
-Hi
+# WhatsApp-Like Backend API (.NET 10, EF Core, PostgreSQL)
+
+Production-ready REST API backend for a WhatsApp-like Android app where:
+- users register with display name only;
+- server generates a unique 8-character code;
+- contacts are added by code;
+- monthly call usage quota is enforced (default 100 minutes/month).
+
+## Tech Stack
+
+- ASP.NET Core Web API (.NET 10)
+- EF Core code-first with PostgreSQL
+- Swagger / OpenAPI
+- Built-in rate limiting (partitioned per IP) on public endpoints
+- ProblemDetails error responses
+- Admin API key auth (`X-Admin-Key`)
+- Docker Compose (API + PostgreSQL)
+
+## Folder Structure
+
+```text
+Minit.Api/
+  Domain/        # Entities + enums
+  Data/          # DbContext + Fluent API configurations
+  Dtos/          # Request/response DTOs
+  Services/      # Quota logic, code generator, middleware, validation
+  Endpoints/     # Minimal API endpoint modules
+  Security/      # Admin API key config/filter
+  Program.cs
+```
+
+## Required Configuration
+
+See `Minit.Api/appsettings.json`:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=minit_api;Username=postgres;Password=postgres"
+  },
+  "Admin": {
+    "ApiKey": "replace-with-a-strong-admin-key"
+  }
+}
+```
+
+## Run with Docker Compose
+
+From repository root:
+
+```bash
+docker compose up --build
+```
+
+- API: `http://localhost:8080`
+- Swagger UI: `http://localhost:8080/swagger`
+- PostgreSQL: `localhost:5432`
+
+## Local Run (without Docker)
+
+1. Ensure PostgreSQL is running and connection string is set in `appsettings.Development.json`.
+2. Restore/build:
+   ```bash
+   dotnet restore
+   dotnet build
+   ```
+3. Run migrations + start app:
+   ```bash
+   dotnet ef migrations add InitialCreate --project Minit.Api --startup-project Minit.Api
+   dotnet ef database update --project Minit.Api --startup-project Minit.Api
+   dotnet run --project Minit.Api
+   ```
+
+## EF Core Migrations Notes
+
+- Migrations folder is intentionally not checked in here because this environment cannot run `dotnet` CLI.
+- The schema is fully migration-ready through:
+  - `AppDbContext`
+  - `Data/EntityConfigurations/*`
+
+Generate/update migrations with:
+
+```bash
+dotnet ef migrations add <MigrationName> --project Minit.Api --startup-project Minit.Api
+dotnet ef database update --project Minit.Api --startup-project Minit.Api
+```
+
+## Implemented Endpoints
+
+### Public Users
+- `POST /api/users/register`
+- `GET /api/users/by-code/{code}`
+
+### Contacts
+- `POST /api/contacts/add`
+- `GET /api/contacts/{ownerUserId}`
+
+### Calls
+- `POST /api/calls/start`
+- `POST /api/calls/{callId}/join`
+- `POST /api/calls/{callId}/end`
+
+### Usage
+- `GET /api/usage/{userId}/month/{yyyymm}`
+
+### Admin (`X-Admin-Key` required)
+- `PATCH /api/admin/users/{userId}/limit`
+- `POST /api/admin/usage-adjustments`
+
+## Behavior Highlights
+
+- Register:
+  - secure RNG generates 8-char code;
+  - retries on collision.
+- Add contact:
+  - by code;
+  - disallow self;
+  - prevent duplicates.
+- Quota:
+  - remaining = `MonthlyLimitSeconds - MonthlyUsage.UsedSeconds` for current UTC month.
+  - start call denied with 403 + `quota_exceeded` when remaining <= 0.
+- End call:
+  - marks ended;
+  - bills full call duration to creator only (MVP rule);
+  - applies usage update transactionally.
+- Admin:
+  - update monthly limit using minutes or seconds;
+  - apply usage adjustments transactionally.
+
+## Sample API Responses
+
+### 1) POST `/api/users/register`
+
+Success (201):
+
+```json
+{
+  "UserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "DisplayName": "Alice",
+  "Code": "K7Q2M8NZ",
+  "MonthlyLimitSeconds": 6000,
+  "CreatedAtUtc": "2026-03-27T10:25:41.122Z"
+}
+```
+
+Error (400):
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "One or more validation errors occurred.",
+  "status": 400,
+  "errors": {
+    "DisplayName": [
+      "The field DisplayName must be a string with a minimum length of 1 and a maximum length of 80."
+    ]
+  },
+  "traceId": "00-4f7ad4e7f4389947d63f07f4893cc6e4-b8f81f03bca7f9a8-00"
+}
+```
+
+### 2) GET `/api/users/by-code/{code}`
+
+Success (200):
+
+```json
+{
+  "UserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "DisplayName": "Alice"
+}
+```
+
+Error (404):
+
+```json
+{
+  "type": "about:blank",
+  "title": "User not found",
+  "status": 404,
+  "detail": "No active user found for the provided code.",
+  "errorCode": "user_not_found",
+  "traceId": "00-2a5f03ef6f5a4d7f2d2528f9c8b65b91-a0417d7e36fb7336-00"
+}
+```
+
+### 3) POST `/api/contacts/add`
+
+Success (201):
+
+```json
+{
+  "ContactId": "80ca84a1-18d7-44de-8e39-2f7728e73f67",
+  "OwnerUserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "ContactUserId": "0c8c9345-7ea5-4894-a4ff-3d309f9ca8bc",
+  "DisplayName": "Bob",
+  "CreatedAtUtc": "2026-03-27T10:31:02.947Z"
+}
+```
+
+Error (409):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Contact already exists",
+  "status": 409,
+  "detail": "This contact is already in the owner's contact list.",
+  "errorCode": "contact_exists",
+  "traceId": "00-20f34e404260fd79f9c0300303b7caeb-8ff83809af6efd33-00"
+}
+```
+
+### 4) GET `/api/contacts/{ownerUserId}`
+
+Success (200):
+
+```json
+[
+  {
+    "ContactUserId": "0c8c9345-7ea5-4894-a4ff-3d309f9ca8bc",
+    "DisplayName": "Bob",
+    "Code": "F5Z1K2QR",
+    "AddedAtUtc": "2026-03-27T10:31:02.947Z"
+  }
+]
+```
+
+Error (404):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Owner not found",
+  "status": 404,
+  "detail": "Owner user does not exist or is inactive.",
+  "errorCode": "owner_not_found",
+  "traceId": "00-d11eb06a2a9a4518dc7e4c47a6f87eb6-e7f5f2f5b92bc9ad-00"
+}
+```
+
+### 5) POST `/api/calls/start`
+
+Success (201):
+
+```json
+{
+  "CallId": "0c4dc5ce-6cc6-4a54-9ca6-ed69431c8ec8",
+  "CreatedByUserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "CalleeUserId": "0c8c9345-7ea5-4894-a4ff-3d309f9ca8bc",
+  "Provider": "agora",
+  "ProviderRoomId": "room-123",
+  "Status": "Active",
+  "StartedAtUtc": "2026-03-27T10:33:11.316Z",
+  "RemainingSecondsBeforeStart": 6000
+}
+```
+
+Error (403):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Quota exceeded",
+  "status": 403,
+  "detail": "No remaining monthly call seconds.",
+  "errorCode": "quota_exceeded",
+  "traceId": "00-c16f5c6d2c7e40999b9f64017af66ce7-38a8f301bd155e8a-00"
+}
+```
+
+### 6) POST `/api/calls/{callId}/join`
+
+Success (200):
+
+```json
+{
+  "ParticipantId": "d4f8f983-6a43-458e-9433-f5e1be7cca3e",
+  "CallSessionId": "0c4dc5ce-6cc6-4a54-9ca6-ed69431c8ec8",
+  "UserId": "0c8c9345-7ea5-4894-a4ff-3d309f9ca8bc",
+  "JoinedAtUtc": "2026-03-27T10:33:21.901Z"
+}
+```
+
+Error (404):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Call not found",
+  "status": 404,
+  "detail": "Call session was not found.",
+  "errorCode": "call_not_found",
+  "traceId": "00-a8f88e4b2d167d3f3abfb06fa414a364-2d3478f039b4f2b8-00"
+}
+```
+
+### 7) POST `/api/calls/{callId}/end`
+
+Success (200):
+
+```json
+{
+  "CallId": "0c4dc5ce-6cc6-4a54-9ca6-ed69431c8ec8",
+  "Status": "Ended",
+  "EndedAtUtc": "2026-03-27T10:40:12.310Z",
+  "BilledSecondsCreator": 421,
+  "BilledUserId": "77f9e38e-8477-4df0-b91a-3605af4549de"
+}
+```
+
+Error (404):
+
+```json
+{
+  "type": "about:blank",
+  "title": "User not found",
+  "status": 404,
+  "detail": "EndedBy user does not exist or is inactive.",
+  "errorCode": "user_not_found",
+  "traceId": "00-7abceeb86b56595c8e9c67f0f4fbe4ce-7b660734ee66978d-00"
+}
+```
+
+### 8) GET `/api/usage/{userId}/month/{yyyymm}`
+
+Success (200):
+
+```json
+{
+  "UserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "MonthYYYYMM": 202603,
+  "MonthlyLimitSeconds": 6000,
+  "UsedSeconds": 421,
+  "RemainingSeconds": 5579,
+  "UpdatedAtUtc": "2026-03-27T10:40:12.315Z"
+}
+```
+
+Error (400):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Invalid month",
+  "status": 400,
+  "detail": "MonthYYYYMM is invalid.",
+  "errorCode": "invalid_month",
+  "traceId": "00-bf9c68f9b41a177f97098ed17f834f0c-17d6f9db12f4a6c8-00"
+}
+```
+
+### 9) PATCH `/api/admin/users/{userId}/limit`
+
+Success (200):
+
+```json
+{
+  "UserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "MonthlyLimitSeconds": 7200,
+  "MonthlyLimitMinutes": 120
+}
+```
+
+Error (401):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "Invalid admin API key.",
+  "errorCode": "admin_key_invalid",
+  "traceId": "00-30ba38b41459ec0806e1f5ef0f4f3aa3-c24a8cd29e95f8de-00"
+}
+```
+
+### 10) POST `/api/admin/usage-adjustments`
+
+Success (201):
+
+```json
+{
+  "Id": "7a2e95f0-dbd4-495a-9f39-0424a6d65f0b",
+  "UserId": "77f9e38e-8477-4df0-b91a-3605af4549de",
+  "MonthYYYYMM": 202603,
+  "DeltaSeconds": -120,
+  "Reason": "Manual correction",
+  "CreatedAtUtc": "2026-03-27T10:42:00.777Z",
+  "NewUsedSeconds": 301
+}
+```
+
+Error (400):
+
+```json
+{
+  "type": "about:blank",
+  "title": "Invalid month",
+  "status": 400,
+  "detail": "MonthYYYYMM is invalid.",
+  "errorCode": "invalid_month",
+  "traceId": "00-728fd0ea6f79db72171f32c5b5427305-30ea4cd60c56f53d-00"
+}
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Minit.Api/Dockerfile
+    container_name: minit-api
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=minitdb;Username=postgres;Password=postgres
+      Admin__ApiKey: super-secret-admin-key
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:17-alpine
+    container_name: minit-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: minitdb
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d minitdb" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Implemented a production-ready .NET 10 minimal API backend for a WhatsApp-like app using clean folder structure:
  - `Domain`, `Data`, `Dtos`, `Services`, `Endpoints`, `Security`
- Added EF Core code-first PostgreSQL data model with fluent configurations, constraints, and indexes:
  - Users, Contacts, CallSessions, CallParticipants, MonthlyUsage, UsageAdjustment
- Implemented all required endpoints:
  - Public user registration/by-code
  - Contact add/list
  - Calls start/join/end
  - Usage month query
  - Admin monthly limit updates + usage adjustments
- Added `QuotaService` with required methods:
  - `GetOrCreateMonthlyUsageAsync`
  - `CheckRemainingSecondsAsync`
  - `ApplyBillingAsync`
- Implemented MVP billing rule at call end:
  - bill full call duration to creator only
  - transactional monthly usage update
- Added admin API key auth via `X-Admin-Key` endpoint filter and `Admin:ApiKey` config
- Added built-in rate limiting per IP for public endpoints (`register`, `by-code`)
- Added global exception middleware and consistent ProblemDetails error responses
- Added Swagger/OpenAPI metadata and response documentation
- Added Docker support:
  - `Minit.Api/Dockerfile`
  - `docker-compose.yml` (API + PostgreSQL)
- Added run instructions, EF migrations instructions, and behavior notes in `Readme`

## Notes
- In this execution environment, `dotnet` CLI was not available, so restore/build/migrations could not be run here.
- Project is migration-ready; run local commands from `Readme` to generate/apply migrations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97c6e09a-d579-4f4d-a231-7dfb55ed6863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97c6e09a-d579-4f4d-a231-7dfb55ed6863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

