### PR TITLE
Add endpoint to set trip active/inactive status

### DIFF
--- a/src/LocationSharing.Api/Contracts/Requests/SetTripStatusRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/SetTripStatusRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class SetTripStatusRequest
+{
+    [Required]
+    public bool? IsActive { get; set; }
+}

--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -102,6 +102,31 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
         return Ok(ToTripResponse(trip));
     }
 
+    [HttpPost("{tripPublicId:guid}/status")]
+    [ProducesResponseType(typeof(TripResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SetTripStatus(
+        [FromRoute] Guid tripPublicId,
+        [FromBody] SetTripStatusRequest request,
+        CancellationToken cancellationToken)
+    {
+        var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
+        if (trip is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Trip not found.");
+        }
+
+        trip.IsActive = request.IsActive!.Value;
+        trip.UpdatedOn = DateTimeOffset.UtcNow;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Ok(ToTripResponse(trip));
+    }
+
     [HttpPost("join")]
     [ProducesResponseType(typeof(TripMemberResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new endpoint `POST /api/trips/{tripPublicId}/status` in `TripsController`
- allow clients to explicitly set `isActive` to true or false for a trip
- add `SetTripStatusRequest` contract with required `isActive` payload
- preserve existing `/api/trips/{tripPublicId}/end` endpoint for backward compatibility

## API
### Request
`POST /api/trips/{tripPublicId}/status`

```json
{
  "isActive": true
}
```

### Response
Returns updated `TripResponse` with the latest `isActive` and `updatedOn` values.

## Notes
- returns `404` when trip is not found
- returns `400` when request body is invalid/missing required `isActive`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20227c4c-ebb2-4fa5-996f-d0871928cb51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20227c4c-ebb2-4fa5-996f-d0871928cb51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

