### PR TITLE
Add endpoint to retrieve trips by member public id

### DIFF
--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -81,6 +81,47 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
         return Ok(ToTripResponse(trip));
     }
 
+    [HttpGet("by-member/{memberPublicId}")]
+    [ProducesResponseType(typeof(IEnumerable<TripResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetTripsByMemberPublicId([FromRoute] string memberPublicId, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(memberPublicId, out var parsedMemberPublicId))
+        {
+            return BadRequest(new ValidationErrorResponse
+            {
+                Message = "The request is invalid.",
+                Errors = new Dictionary<string, string[]>
+                {
+                    ["memberPublicId"] = ["The memberPublicId must be a valid GUID."]
+                }
+            });
+        }
+
+        var member = await dbContext.Members
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.PublicId == parsedMemberPublicId, cancellationToken);
+        if (member is null)
+        {
+            return this.ProblemWithTrace(
+                StatusCodes.Status404NotFound,
+                "Not Found",
+                "Member not found.");
+        }
+
+        var trips = await (
+            from tripMember in dbContext.TripMembers.AsNoTracking()
+            join trip in dbContext.Trips.AsNoTracking()
+                on tripMember.TripId equals trip.Id
+            where tripMember.MemberId == member.Id
+            select trip)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        return Ok(trips.Select(ToTripResponse));
+    }
+
     [HttpPost("{tripPublicId:guid}/end")]
     [ProducesResponseType(typeof(TripResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `GET /api/trips/by-member/{memberPublicId}` to `TripsController`
- validate route parameter as GUID and return `400` with validation payload when invalid
- return `404` when member is not found
- query memberships from `TripMembers` and join to `Trips` as source of truth
- return deduplicated trips mapped to existing `TripResponse` shape, including inactive memberships

## Notes
- `200` returns an empty list when the member exists but has no trip memberships
- implemented with a single join query (`AsNoTracking` + `Distinct`) to avoid N+1 lookups

## Testing
- attempted to run `dotnet build LocationSharing.sln`, but `.NET SDK` is not available in this cloud environment (`dotnet: command not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f80a1e1-ea03-46fd-b37b-ad7e32e9db79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f80a1e1-ea03-46fd-b37b-ad7e32e9db79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

