### PR TITLE
Enhance EndTrip endpoint to persist optional end location

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,20 @@ dotnet ef database update --project src/LocationSharing.Api --startup-project sr
 
 ### 5) POST `/api/trips/{tripPublicId}/end`
 
+**Request body (optional for backward compatibility):**
+
+```json
+{
+  "endLatitude": 25.2048,
+  "endLongitude": 55.2708
+}
+```
+
+Both `endLatitude` and `endLongitude` are optional. Older clients can continue calling the endpoint without a request body.
+If provided, both fields must be provided together and must be valid coordinates:
+- `endLatitude`: `-90` to `90`
+- `endLongitude`: `-180` to `180`
+
 **Success (200):**
 
 ```json

--- a/src/LocationSharing.Api/Contracts/Requests/EndTripRequest.cs
+++ b/src/LocationSharing.Api/Contracts/Requests/EndTripRequest.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LocationSharing.Api.Contracts.Requests;
+
+public class EndTripRequest : IValidatableObject
+{
+    [Range(-90, 90)]
+    public double? EndLatitude { get; set; }
+
+    [Range(-180, 180)]
+    public double? EndLongitude { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (EndLatitude.HasValue != EndLongitude.HasValue)
+        {
+            yield return new ValidationResult(
+                "EndLatitude and EndLongitude must both be provided when setting an end location.",
+                [nameof(EndLatitude), nameof(EndLongitude)]);
+        }
+
+        if (EndLatitude.HasValue && double.IsNaN(EndLatitude.Value))
+        {
+            yield return new ValidationResult(
+                "EndLatitude must be a valid number.",
+                [nameof(EndLatitude)]);
+        }
+
+        if (EndLatitude.HasValue && double.IsInfinity(EndLatitude.Value))
+        {
+            yield return new ValidationResult(
+                "EndLatitude must be a finite number.",
+                [nameof(EndLatitude)]);
+        }
+
+        if (EndLongitude.HasValue && double.IsNaN(EndLongitude.Value))
+        {
+            yield return new ValidationResult(
+                "EndLongitude must be a valid number.",
+                [nameof(EndLongitude)]);
+        }
+
+        if (EndLongitude.HasValue && double.IsInfinity(EndLongitude.Value))
+        {
+            yield return new ValidationResult(
+                "EndLongitude must be a finite number.",
+                [nameof(EndLongitude)]);
+        }
+    }
+}

--- a/src/LocationSharing.Api/Controllers/TripsController.cs
+++ b/src/LocationSharing.Api/Controllers/TripsController.cs
@@ -124,8 +124,12 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
 
     [HttpPost("{tripPublicId:guid}/end")]
     [ProducesResponseType(typeof(TripResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ValidationErrorResponse), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> EndTrip([FromRoute] Guid tripPublicId, CancellationToken cancellationToken)
+    public async Task<IActionResult> EndTrip(
+        [FromRoute] Guid tripPublicId,
+        [FromBody] EndTripRequest? request,
+        CancellationToken cancellationToken)
     {
         var trip = await dbContext.Trips.FirstOrDefaultAsync(t => t.PublicId == tripPublicId, cancellationToken);
         if (trip is null)
@@ -136,8 +140,25 @@ public class TripsController(LocationSharingDbContext dbContext) : ControllerBas
                 "Trip not found.");
         }
 
+        var now = DateTimeOffset.UtcNow;
+        var hasEndedAlready = !trip.IsActive;
+
+        if (request?.EndLatitude.HasValue == true && request.EndLongitude.HasValue)
+        {
+            if (!hasEndedAlready || !trip.EndLatitude.HasValue || !trip.EndLongitude.HasValue)
+            {
+                trip.EndLatitude = request.EndLatitude.Value;
+                trip.EndLongitude = request.EndLongitude.Value;
+            }
+        }
+
         trip.IsActive = false;
-        trip.UpdatedOn = DateTimeOffset.UtcNow;
+        if (trip.EndTime == default || trip.EndTime > now)
+        {
+            trip.EndTime = now;
+        }
+
+        trip.UpdatedOn = now;
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return Ok(ToTripResponse(trip));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- updated the existing `POST /api/trips/{tripPublicId}/end` endpoint to accept an optional JSON body via new `EndTripRequest`
- added validation for end coordinates (`endLatitude` in `[-90, 90]`, `endLongitude` in `[-180, 180]`) and require both fields together when provided
- preserved backward compatibility by allowing older clients to call the endpoint without a request body
- made end-trip behavior idempotent-friendly by:
  - always setting `IsActive = false`
  - setting `EndTime` only when unset/default or still in the future
  - only writing end coordinates when request values are present and the trip has not already stored an end location
- updated README API docs for the `/end` endpoint request payload and validation behavior

## Validation
- attempted project build: `dotnet build src/LocationSharing.Api/LocationSharing.Api.csproj`
- result: failed in cloud environment because `dotnet` is not installed (`dotnet: command not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d833ccfc-235c-467b-8301-f8bd6c187e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d833ccfc-235c-467b-8301-f8bd6c187e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

